### PR TITLE
OpenShift yaml health probes with custom image name

### DIFF
--- a/007-openshift-yaml-health-probes/pom.xml
+++ b/007-openshift-yaml-health-probes/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.quarkus.qe</groupId>
+    <artifactId>beefy-scenarios</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>007-openshift-yaml-health-probes</artifactId>
+  
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-openshift</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- failsafe needs to run in JVM mode as the yaml files are generated after test phase -->
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/007-openshift-yaml-health-probes/src/main/java/io/quarkus/qe/openshift/GreetingResource.java
+++ b/007-openshift-yaml-health-probes/src/main/java/io/quarkus/qe/openshift/GreetingResource.java
@@ -1,0 +1,16 @@
+package io.quarkus.qe.openshift;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "hello";
+    }
+}

--- a/007-openshift-yaml-health-probes/src/main/resources/application.properties
+++ b/007-openshift-yaml-health-probes/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.container-image.name=demo

--- a/007-openshift-yaml-health-probes/src/test/java/io/quarkus/qe/openshift/OpenShiftYamlHealthProbesIT.java
+++ b/007-openshift-yaml-health-probes/src/test/java/io/quarkus/qe/openshift/OpenShiftYamlHealthProbesIT.java
@@ -1,0 +1,49 @@
+package org.acme.quickstart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+public class OpenShiftYamlHealthProbesIT {
+
+    @Test
+    public void testOpenShiftYamlHealthProbesWithCustomImageName() throws FileNotFoundException {
+        String path = "target/kubernetes/kubernetes.yml";
+        File file = new File(path);
+        assertTrue(file.exists(), "File " + path + " doesn't exist");
+
+        Yaml yaml = new Yaml();
+        InputStream inputStream = new FileInputStream(new File(path));
+        boolean deploymentDefinitionFound = false;
+        for (Object object : yaml.loadAll(inputStream)) {
+            Map<String, Object> map = (Map<String, Object>) object;
+            if (map.get("kind").equals("Deployment")) {
+                deploymentDefinitionFound = true;
+
+                Map<String, Object> xmap = (Map<String, Object>) map.get("spec");
+                Map<String, Object> ymap = (Map<String, Object>) xmap.get("template");
+                Map<String, Object> zmap = (Map<String, Object>) ymap.get("spec");
+                Map<String, Object> finalMap = (Map<String, Object>) ((List) zmap.get("containers")).get(0);
+
+                // finalMap.entrySet().forEach(System.out::println);
+
+                assertEquals("demo", finalMap.get("name"), "Deployment name is not expected 'demo'");
+                assertTrue(finalMap.containsKey("livenessProbe"), "livenessProbe is not defined");
+                assertTrue(finalMap.containsKey("readinessProbe"), "readinessProbe is not defined");
+            }
+        }
+        if (!deploymentDefinitionFound) {
+            fail("Parsed yaml file didn't have expected Deployment definition");
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
 
   <modules>
       <module>001-quarkus-getting-started</module>
-      <module>101-javaee-like-getting-started</module>
-      <module>201-large-static-content</module>
       <module>002-quarkus-all-extensions</module>
       <module>003-quarkus-many-extensions</module>
       <module>004-quarkus-HHH-and-HV</module>
       <module>005-quarkus-and-maven-profiles</module>
       <module>006-quartz-manually-scheduled-job</module>
+      <module>101-javaee-like-getting-started</module>
+      <module>201-large-static-content</module>
       <module>601-spring-data-primitive-types</module>
   </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
       <module>004-quarkus-HHH-and-HV</module>
       <module>005-quarkus-and-maven-profiles</module>
       <module>006-quartz-manually-scheduled-job</module>
+      <module>007-openshift-yaml-health-probes</module>
       <module>101-javaee-like-getting-started</module>
       <module>201-large-static-content</module>
       <module>601-spring-data-primitive-types</module>


### PR DESCRIPTION
OpenShift yaml health probes with custom image name

Test is using `quarkus-openshift` extension and not the kubernetes one.