### PR TITLE
Move to newer version of joschi/setup-jdk to be in sync with version used in Quarkus master

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -18,9 +18,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@v1.0.0
+        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
         with:
-          java-version: openjdk${{ matrix.java }}
+          java-version: ${{ matrix.java }}
       - name: Build Quarkus master
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -Dquickly
@@ -51,9 +51,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@v1.0.0
+        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
         with:
-          java-version: openjdk${{ matrix.java }}
+          java-version: ${{ matrix.java }}
       - name: Build Quarkus master
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -Dquickly

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,9 +17,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK {{ matrix.java }}
-        uses: joschi/setup-jdk@v1.0.0
+        uses: joschi/setup-jdk@b9cc6eabf7e7e3889766b5cee486f874c9e1bd2d
         with:
-          java-version: openjdk${{ matrix.java }}
+          java-version: ${{ matrix.java }}
       - name: Build Quarkus master
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -DskipTests -DskipITs


### PR DESCRIPTION
Move to newer version of joschi/setup-jdk to be in sync with version used in Quarkus master