### PR TITLE
Remove universe extensions, we cover core ones, we do not need to handle external extensions

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -544,26 +544,5 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-webjars-locator</artifactId>
         </dependency>
-
     </dependencies>
-    <profiles>
-        <profile>
-            <id>extensions-from-quarkus-universe</id>
-            <dependencies>
-                <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-outbox</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-hazelcast-client</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-client</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
-
 </project>


### PR DESCRIPTION
Remove universe extensions, we cover core ones, we do not need to handle external extensions

Those extensions are troublesome, just filed issues for Cassandra and Outbox