### PR TITLE
quarkus-hibernate-search-elasticsearch was renamed to quarkus-hibernate-search-orm-elasticsearch

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -115,7 +115,7 @@
         <!--  NATIVE mode issue -->
         <!-- <dependency>
           <groupId>io.quarkus</groupId>
-          <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
+          <artifactId>quarkus-hibernate-search-orm-elasticsearch</artifactId>
         </dependency> -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -304,7 +304,7 @@
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-hibernate-search-elasticsearch</artifactId>
+        <artifactId>quarkus-hibernate-search-orm-elasticsearch</artifactId>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>


### PR DESCRIPTION
quarkus-hibernate-search-elasticsearch was renamed to quarkus-hibernate-search-orm-elasticsearch

done in #12790 in https://github.com/quarkusio/quarkus