### PR TITLE
Added opentracing, resteasy, mutiny example

### DIFF
--- a/010-quarkus-opentracing-reactive-grpc/README.md
+++ b/010-quarkus-opentracing-reactive-grpc/README.md
@@ -1,0 +1,4 @@
+Module that test whether the opentracing data is transmitted among REST resources using Rest Client.
+There are two applications:
+- Ping application that will invoke the Pong application using the RestClient and will return the expected "ping pong" output.
+- Pong application that will return the "pong" output.

--- a/010-quarkus-opentracing-reactive-grpc/pom.xml
+++ b/010-quarkus-opentracing-reactive-grpc/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>beefy-scenarios</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>010-quarkus-opentracing-reactive-grpc</artifactId>
+
+    <dependencies>        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-mutiny</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-opentracing</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/GrpcPingResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/GrpcPingResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe.ping;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.example.PongRequest;
+import io.quarkus.example.PongServiceGrpc;
+import io.quarkus.grpc.runtime.annotations.GrpcService;
+import io.quarkus.qe.traceable.TraceableResource;
+
+@Path("/grpc-ping")
+public class GrpcPingResource extends TraceableResource {
+
+    @Inject
+    @GrpcService("pong")
+    PongServiceGrpc.PongServiceBlockingStub pongClient;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getPing() {
+        recordTraceId();
+
+        return "ping " + pongClient.sayPong(PongRequest.newBuilder().build()).getMessage();
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/PingResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/PingResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe.ping;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.qe.ping.clients.PongClient;
+import io.quarkus.qe.traceable.TraceableResource;
+
+@Path("/rest-ping")
+public class PingResource extends TraceableResource {
+
+    @Inject
+    @RestClient
+    PongClient pongClient;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getPing() {
+        recordTraceId();
+
+        return "ping " + pongClient.getPong();
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/ReactivePingResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/ReactivePingResource.java
@@ -1,0 +1,30 @@
+package io.quarkus.qe.ping;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.qe.ping.clients.ReactivePongClient;
+import io.quarkus.qe.traceable.TraceableResource;
+import io.smallrye.mutiny.Uni;
+
+@Path("/reactive-ping")
+public class ReactivePingResource extends TraceableResource {
+
+    @Inject
+    @RestClient
+    ReactivePongClient pongClient;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> getPing() {
+        recordTraceId();
+        return pongClient.getPong().onItem().transform(response -> {
+            return "ping " + response;
+        });
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/clients/PongClient.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/clients/PongClient.java
@@ -1,0 +1,17 @@
+package io.quarkus.qe.ping.clients;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient
+public interface PongClient {
+    @GET
+    @Path("/rest-pong")
+    @Produces(MediaType.TEXT_PLAIN)
+    String getPong();
+
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/clients/ReactivePongClient.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/clients/ReactivePongClient.java
@@ -1,0 +1,19 @@
+package io.quarkus.qe.ping.clients;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import io.smallrye.mutiny.Uni;
+
+@RegisterRestClient
+public interface ReactivePongClient {
+    @GET
+    @Path("/reactive-pong")
+    @Produces(MediaType.TEXT_PLAIN)
+    Uni<String> getPong();
+
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/pong/GrpcPongService.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/pong/GrpcPongService.java
@@ -1,0 +1,27 @@
+package io.quarkus.qe.pong;
+
+import javax.inject.Singleton;
+
+import org.jboss.logmanager.MDC;
+
+import io.grpc.stub.StreamObserver;
+import io.quarkus.example.PongReply;
+import io.quarkus.example.PongRequest;
+import io.quarkus.example.PongServiceGrpc;
+
+@Singleton
+public class GrpcPongService extends PongServiceGrpc.PongServiceImplBase {
+
+    private String lastTraceId;
+
+    @Override
+    public void sayPong(PongRequest request, StreamObserver<PongReply> responseObserver) {
+        lastTraceId = MDC.get("traceId");
+        responseObserver.onNext(PongReply.newBuilder().setMessage("pong").build());
+        responseObserver.onCompleted();
+    }
+
+    public String getLastTraceId() {
+        return lastTraceId;
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/pong/PongResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/pong/PongResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.qe.pong;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qe.traceable.TraceableResource;
+
+@Path("/rest-pong")
+public class PongResource extends TraceableResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getPong() {
+        recordTraceId();
+        return "pong";
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/pong/ReactivePongResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/pong/ReactivePongResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.qe.pong;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qe.traceable.TraceableResource;
+import io.smallrye.mutiny.Uni;
+
+@Path("/reactive-pong")
+public class ReactivePongResource extends TraceableResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Uni<String> getPong() {
+        recordTraceId();
+        return Uni.createFrom().item("pong");
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/traceable/TraceableResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/traceable/TraceableResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe.traceable;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.logging.Logger;
+import org.jboss.logmanager.MDC;
+
+public abstract class TraceableResource {
+
+    private static final Logger LOG = Logger.getLogger(TraceableResource.class);
+
+    private String lastTraceId;
+
+    @GET
+    @Path("/lastTraceId")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getLastTraceId() {
+        return lastTraceId;
+    }
+
+    protected void recordTraceId() {
+        lastTraceId = MDC.get("traceId");
+        LOG.info("Recorded trace ID: " + lastTraceId);
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/proto/pong.proto
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/proto/pong.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.example";
+option java_outer_classname = "PongProto";
+
+package io.quarkus.example;
+
+service PongService {
+    rpc SayPong (PongRequest) returns (PongReply) {}
+}
+
+message PongRequest {
+}
+
+message PongReply {
+    string message = 1;
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/resources/application.properties
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+# Quarkus
+quarkus.http.port=8081
+
+# Jaeger
+quarkus.jaeger.service-name=pingpong
+quarkus.jaeger.sampler-type=const
+quarkus.jaeger.sampler-param=1
+quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n
+
+# RestClient
+io.quarkus.qe.ping.clients.PongClient/mp-rest/url=http://localhost:8081
+io.quarkus.qe.ping.clients.PongClient/mp-rest/scope=javax.inject.Singleton 
+
+io.quarkus.qe.ping.clients.ReactivePongClient/mp-rest/url=http://localhost:8081
+io.quarkus.qe.ping.clients.ReactivePongClient/mp-rest/scope=javax.inject.Singleton
+
+# gRPC
+quarkus.grpc.clients.pong.host=localhost

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
@@ -1,0 +1,70 @@
+package io.quarkus.qe;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpStatus;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.qe.containers.JaegerTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
+
+@QuarkusTestResource(JaegerTestResource.class)
+public abstract class AbstractPingPongResourceTest {
+
+    private static final String PING_ENDPOINT = "/%s-ping";
+    private static final String PONG_ENDPOINT = "/%s-pong";
+
+    private static final String PING_RESOURCE = "PingResource";
+    private static final String PONG_RESOURCE = "PongResource";
+
+    @ConfigProperty(name = JaegerTestResource.JAEGER_API_ENDPOINT, defaultValue = "http://localhost:16686/api/traces")
+    String jaegerEndpoint;
+
+    @Test
+    public void testPingPong() {
+        // When calling ping, the rest will invoke also the pong rest endpoint.
+        given()
+                .when().get(pingEndpoint())
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is("ping pong"));
+
+        // Then both ping and pong rest endpoints should have the same trace Id.
+        String pingTraceId = given()
+                .when().get(pingEndpoint() + "/lastTraceId")
+                .then().statusCode(HttpStatus.SC_OK).and().extract().asString();
+
+        assertTraceIdWithPongService(pingTraceId);
+
+        // Then Jaeger is invoked
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> given()
+                .when().get(jaegerEndpoint + "/" + pingTraceId)
+                .then().statusCode(HttpStatus.SC_OK)
+                .and().body(allOf(containsString(PING_RESOURCE), containsString(PONG_RESOURCE))));
+    }
+
+    protected abstract String endpointPrefix();
+
+    protected void assertTraceIdWithPongService(String expected) {
+        String pongTraceId = given()
+                .when().get(pongEndpoint() + "/lastTraceId")
+                .then().statusCode(HttpStatus.SC_OK).and().extract().asString();
+
+        assertEquals(expected, pongTraceId);
+    }
+
+    private String pingEndpoint() {
+        return String.format(PING_ENDPOINT, endpointPrefix());
+    }
+
+    private String pongEndpoint() {
+        return String.format(PONG_ENDPOINT, endpointPrefix());
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/GrpcPingPongResourceTest.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/GrpcPingPongResourceTest.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Disabled;
+
+import io.quarkus.qe.pong.GrpcPongService;
+import io.quarkus.test.junit.QuarkusTest;
+
+@Disabled("Caused by https://github.com/quarkusio/quarkus/issues/13224")
+@QuarkusTest
+public class GrpcPingPongResourceTest extends AbstractPingPongResourceTest {
+
+    @Inject
+    GrpcPongService pongService;
+
+    @Override
+    protected String endpointPrefix() {
+        return "grpc";
+    }
+
+    @Override
+    protected void assertTraceIdWithPongService(String expected) {
+        assertEquals(expected, pongService.getLastTraceId());
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeReactivePingPongResourceIT.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeReactivePingPongResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeReactivePingPongResourceIT extends ReactivePingPongResourceTest {
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeRestPingPongResourceIT.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeRestPingPongResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeRestPingPongResourceIT extends RestPingPongResourceTest {
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/ReactivePingPongResourceTest.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/ReactivePingPongResourceTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ReactivePingPongResourceTest extends AbstractPingPongResourceTest {
+
+    @Override
+    protected String endpointPrefix() {
+        return "reactive";
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/RestPingPongResourceTest.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/RestPingPongResourceTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class RestPingPongResourceTest extends AbstractPingPongResourceTest {
+
+    @Override
+    protected String endpointPrefix() {
+        return "rest";
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/containers/JaegerTestResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/containers/JaegerTestResource.java
@@ -1,0 +1,69 @@
+package io.quarkus.qe.containers;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.testcontainers.containers.GenericContainer;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class JaegerTestResource implements QuarkusTestResourceLifecycleManager {
+
+    public static final String JAEGER_API_ENDPOINT = "jaeger.api.endpoint";
+
+    private static final String JAEGER_ENDPOINT = "http://%s:%s/api/traces";
+    private static final int TRACE_PORT = 14268;
+    private static final int REST_PORT = 16686;
+    private static final String QUARKUS_JAEGER_PROPERTY = "quarkus.jaeger.endpoint";
+
+    private GenericContainer<?> container;
+
+    @Override
+    public Map<String, String> start() {
+
+        container = new GenericContainer<>("jaegertracing/all-in-one:latest");
+        container.start();
+
+        return Collections.singletonMap(QUARKUS_JAEGER_PROPERTY, traceEndpoint());
+    }
+
+    @Override
+    public void stop() {
+        Optional.ofNullable(container).ifPresent(GenericContainer::stop);
+    }
+
+    @Override
+    public void inject(Object testInstance) {
+        Class<?> c = testInstance.getClass();
+        while (c != Object.class) {
+            for (Field f : c.getDeclaredFields()) {
+                ConfigProperty configProperty = f.getAnnotation(ConfigProperty.class);
+                if (configProperty != null && JAEGER_API_ENDPOINT.equals(configProperty.name())) {
+                    setFieldValue(f, testInstance, apiEndpoint());
+                }
+            }
+            c = c.getSuperclass();
+        }
+    }
+
+    private String traceEndpoint() {
+        return String.format(JAEGER_ENDPOINT, container.getContainerIpAddress(), container.getMappedPort(TRACE_PORT));
+    }
+
+    private String apiEndpoint() {
+        return String.format(JAEGER_ENDPOINT, container.getContainerIpAddress(), container.getMappedPort(REST_PORT));
+    }
+
+    private void setFieldValue(Field f, Object testInstance, Object value) {
+        try {
+            f.setAccessible(true);
+            f.set(testInstance, value);
+            return;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Module that test whether the OpenTracing data is transmitted among services.
There are two applications:
- Ping application that will invoke the Pong application using the RestClient and will return the expected "ping pong" output.
- Pong application that will return the "pong" output.

We're covering:
- Among REST services
- Among Reactive services
- With REST service to gRPC (this is not working... should be an issue? If not, I guess we should delete this).

Note that we don't need a running Jaeger to see this functionality working. This was odd to me at first and perhaps we should verify that indeed Jaeger is getting the metrics. Let me know your thoughts about this. @rsvoboda @mjurc 