### PR TITLE
Use Google mirror when building Quarkus master to avoid connection reset from central

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -23,7 +23,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus master
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -Dquickly
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B -s .github/mvn-settings.xml clean install -Dquickly
       - name: Test in JVM mode
         run: |
           mvn -V -B -fae clean verify
@@ -56,7 +56,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus master
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -Dquickly
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B -s .github/mvn-settings.xmlclean install -Dquickly
       - name: Test in Native mode
         run: |
           mvn -V -B -fae clean verify -Dnative \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,7 +22,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus master
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B clean install -DskipTests -DskipITs
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B -s .github/mvn-settings.xml clean install -DskipTests -DskipITs
       - name: Test in JVM mode
         run: |
           mvn -V -B clean test


### PR DESCRIPTION
Use Google mirror when building Quarkus master to avoid connection reset from central

50% of runs in https://github.com/quarkus-qe/beefy-scenarios/actions failed in last couple of days because of connection reset received from central