### PR TITLE
panache-rest-flyway: add many-to-one relationship with string id

### DIFF
--- a/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/ApplicationEntity.java
+++ b/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/ApplicationEntity.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotEmpty;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
@@ -11,4 +14,8 @@ public class ApplicationEntity extends PanacheEntity {
     @NotEmpty
     @Column(unique = true, nullable = false)
     public String name;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "version_id", nullable = false)
+    public VersionEntity version;
 }

--- a/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/VersionEntity.java
+++ b/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/VersionEntity.java
@@ -1,0 +1,12 @@
+package io.quarkus.qe;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
+@Entity(name = "version")
+public class VersionEntity extends PanacheEntityBase {
+    @Id
+    public String id;
+}

--- a/011-quarkus-panache-rest-flyway/src/main/resources/db/migration/V1.0.1__entity_with_id_varchar.sql
+++ b/011-quarkus-panache-rest-flyway/src/main/resources/db/migration/V1.0.1__entity_with_id_varchar.sql
@@ -1,0 +1,6 @@
+CREATE TABLE version
+(
+  id          VARCHAR(100) PRIMARY KEY
+);
+
+ALTER TABLE application ADD COLUMN version_id VARCHAR(100) REFERENCES version(id);

--- a/011-quarkus-panache-rest-flyway/src/test/java/io/quarkus/qe/PostgreSqlApplicationResourceTest.java
+++ b/011-quarkus-panache-rest-flyway/src/test/java/io/quarkus/qe/PostgreSqlApplicationResourceTest.java
@@ -25,6 +25,7 @@ import io.restassured.specification.RequestSpecification;
 public class PostgreSqlApplicationResourceTest {
 
     private static final String APPLICATION_PATH = "/application";
+    private static final String EXPECTED_VERSION = "1.2.0";
 
     private ApplicationEntity actualEntity;
     private ApplicationEntity[] actualList;
@@ -78,6 +79,8 @@ public class PostgreSqlApplicationResourceTest {
     private void whenCreateApplication(String appName) {
         ApplicationEntity request = new ApplicationEntity();
         request.name = appName;
+        request.version = new VersionEntity();
+        request.version.id = EXPECTED_VERSION;
         actualEntity = applicationPath().body(request).post()
                 .then()
                 .statusCode(HttpStatus.SC_CREATED)
@@ -104,6 +107,7 @@ public class PostgreSqlApplicationResourceTest {
     private void thenApplicationMatches(String expectedAppName) {
         assertNotNull(actualEntity.id);
         assertEquals(expectedAppName, actualEntity.name);
+        assertEquals(EXPECTED_VERSION, actualEntity.version.id);
     }
 
     private void thenApplicationsCountIs(int expectedCount) {


### PR DESCRIPTION
Added a new check to cover the many-to-one relationship in the Panache REST flyway module. 