### PR TITLE
Add filters coverage in panache-rest module

### DIFF
--- a/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/ApplicationEntity.java
+++ b/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/ApplicationEntity.java
@@ -1,15 +1,32 @@
 package io.quarkus.qe;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Transient;
 import javax.validation.constraints.NotEmpty;
+
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+import org.hibernate.annotations.SqlFragmentAlias;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 
 @Entity(name = "application")
+@FilterDef(name = "useLikeByName", parameters = { @ParamDef(name = "name", type = "string") })
+@Filter(name = "useLikeByName", condition = "name like '%' || :name || '%'")
+@FilterDef(name = "useServiceByName", parameters = { @ParamDef(name = "name", type = "string") })
 public class ApplicationEntity extends PanacheEntity {
     @NotEmpty
     @Column(unique = true, nullable = false)
@@ -18,4 +35,16 @@ public class ApplicationEntity extends PanacheEntity {
     @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "version_id", nullable = false)
     public VersionEntity version;
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @Filter(name = "useServiceByName", condition = "{s}.name = :name", aliases = {
+            @SqlFragmentAlias(alias = "s", table = "service")
+    })
+    public List<ServiceEntity> services = new ArrayList<>();
+
+    @Transient
+    public Optional<ServiceEntity> getServiceByName(String serviceName) {
+        return services.stream().filter(s -> serviceName.equals(s.name)).findFirst();
+    }
 }

--- a/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/ApplicationQueryResource.java
+++ b/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/ApplicationQueryResource.java
@@ -1,0 +1,41 @@
+package io.quarkus.qe;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+
+@Path("/application/filterBy")
+@Transactional
+public class ApplicationQueryResource {
+    @GET
+    @Path("/{filterName}")
+    @Produces("application/json")
+    public List<ApplicationEntity> filterBy(@PathParam("filterName") String filterName, @Context UriInfo uriInfo) {
+        PanacheQuery<ApplicationEntity> query = ApplicationEntity.<ApplicationEntity> findAll()
+                .filter(filterName, asMap(uriInfo.getQueryParameters()));
+        return query.list();
+    }
+
+    private Map<String, Object> asMap(MultivaluedMap<String, String> map) {
+        if (map == null) {
+            return Collections.emptyMap();
+        }
+
+        return map.entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey,
+                        e -> e.getValue().stream().collect(Collectors.joining(","))));
+    }
+}

--- a/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/ServiceEntity.java
+++ b/011-quarkus-panache-rest-flyway/src/main/java/io/quarkus/qe/ServiceEntity.java
@@ -1,0 +1,21 @@
+package io.quarkus.qe;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+
+@Entity(name = "service")
+public class ServiceEntity extends PanacheEntity {
+    @Column(nullable = false)
+    public String name;
+
+    @ManyToOne
+    @JoinColumn(name = "application_id", nullable = false)
+    @JsonBackReference
+    public ApplicationEntity application;
+}

--- a/011-quarkus-panache-rest-flyway/src/main/resources/db/migration/V1.0.2__add_service.sql
+++ b/011-quarkus-panache-rest-flyway/src/main/resources/db/migration/V1.0.2__add_service.sql
@@ -1,0 +1,6 @@
+CREATE TABLE service
+(
+  id              BIGINT PRIMARY KEY,
+  name            VARCHAR(100) NOT NULL,
+  application_id  BIGINT NOT NULL REFERENCES application(id)
+);


### PR DESCRIPTION
The objective of these changes is to coverage the `@Filter` and reproduce the missing functionality to use `@FilterJoinTable` (reported by https://github.com/quarkusio/quarkus/issues/13831).