### PR TITLE
Add Deprecated annotation to JaxRs resource

### DIFF
--- a/001-quarkus-getting-started/src/main/java/io/quarkus/qe/core/GreetingResource.java
+++ b/001-quarkus-getting-started/src/main/java/io/quarkus/qe/core/GreetingResource.java
@@ -5,6 +5,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+@Deprecated
 @Path("/hello")
 public class GreetingResource {
 


### PR DESCRIPTION
TD for https://issues.redhat.com/browse/QUARKUS-533
Check that java.lang annotations are allowed in resource prefix