### PR TITLE
Spring beans and JPA test coverage

### DIFF
--- a/601-spring-data-primitive-types/README.md
+++ b/601-spring-data-primitive-types/README.md
@@ -1,0 +1,25 @@
+# Quarkus Spring Extension
+
+Issues References:
+-----------------------------
+[Fix spring-data-jpa field lookup with layered @MappedSuperclasses](https://issues.redhat.com/browse/QUARKUS-532)
+[Make embedded fields with camel-case work in Spring Data JPA repositories](https://issues.redhat.com/browse/QUARKUS-525)
+[Spring's @Scope#scopeName is now taken into account](https://issues.redhat.com/browse/QUARKUS-547)
+
+### Fix spring-data-jpa field lookup with layered @MappedSuperclasses
+
+We have added a "super" structure over the existing Cat entity. 
+So currently,  Cats extends Mammal and mammal are animals.
+
+### Make embedded fields with camel-case work in Spring Data JPA repositories
+
+We've created a query over an embedded camelCase field.
+
+### Spring's @Scope#scopeName is now taken into account
+
+We've created an HTTP Request filter in order to add headers to the response:
+
+- x-session: Keep the same value per HTTP session
+- x-count: count the number of requests
+- x-request: increase his value per HTTP request
+- x-instance: represents the instance ID. Must be a unique per pod/instance. 

--- a/601-spring-data-primitive-types/pom.xml
+++ b/601-spring-data-primitive-types/pom.xml
@@ -15,6 +15,14 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-spring-di</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-jsonb</artifactId>
         </dependency>
         <dependency>

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/BookRepository.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/BookRepository.java
@@ -1,5 +1,7 @@
 package io.quarkus.qe.spring.data;
 
+import io.quarkus.qe.spring.data.model.Book;
+import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +23,7 @@ public interface BookRepository extends Repository<Book, Integer> {
     // issue 9192
     @Query(value = "SELECT b.isbn FROM Book b where b.bid = :bid")
     Long customFindPublicationIsbnObject(@Param("bid") Integer bid);
+
+    // issue QUARKUS-525
+    List<Book> findByPublisherAddressZipCode(@Param("zipCode") String zipCode);
 }

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/BookResource.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/BookResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.qe.spring.data;
 
+import io.quarkus.qe.spring.data.model.Book;
+import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -40,6 +42,13 @@ public class BookResource {
     @Produces("text/plain")
     public Long customFindPublicationIsbnObject(@PathParam("bid") Integer bid) {
         return bookRepository.customFindPublicationIsbnObject(bid);
+    }
+
+    @GET
+    @Path("/publisher/zipcode/{zipCode}")
+    @Produces("application/json")
+    public List<Book> findBooksByPublicationYear(@PathParam("zipCode") String zipCode) {
+        return bookRepository.findByPublisherAddressZipCode(zipCode);
     }
 
 }

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/CatRepository.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/CatRepository.java
@@ -1,5 +1,7 @@
 package io.quarkus.qe.spring.data;
 
+import io.quarkus.qe.spring.data.model.Cat;
+import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +15,7 @@ public interface CatRepository extends CrudRepository<Cat, Long> {
     // issue 9192
     @Query(value = "SELECT c.distinctive FROM Cat c where c.id = :id")
     Boolean customFindDistinctiveObject(@Param("id") Long id);
+
+    @Query(value = "SELECT c FROM Cat c where c.deathReason = :reason")
+    List<Cat> findCatsByDeathReason(@Param("reason") String reason);
 }

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/CatResource.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/CatResource.java
@@ -1,5 +1,7 @@
 package io.quarkus.qe.spring.data;
 
+import io.quarkus.qe.spring.data.model.Cat;
+import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -26,5 +28,12 @@ public class CatResource {
     @Produces("text/plain")
     public Boolean customFindDistinctiveObject(@PathParam("id") Long id) {
         return catRepository.customFindDistinctiveObject(id);
+    }
+
+    @GET
+    @Path("/findCatsByMappedSuperclassField/{deathReason}")
+    @Produces("application/json")
+    public List<Cat> findCatsByMappedSuperclassField(@PathParam("deathReason") String deathReason) {
+        return catRepository.findCatsByDeathReason(deathReason);
     }
 }

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/HttpCommonsHeaders.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/HttpCommonsHeaders.java
@@ -1,0 +1,35 @@
+package io.quarkus.qe.spring.data;
+
+import io.quarkus.qe.spring.data.configuration.InstanceIdBean;
+import io.quarkus.qe.spring.data.configuration.RequestIdBean;
+import io.quarkus.qe.spring.data.configuration.SessionIdBean;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import static io.quarkus.qe.spring.data.configuration.AppConfiguration.getAndIncIndex;
+
+@Provider
+public class HttpCommonsHeaders implements ContainerResponseFilter {
+
+    @Inject
+    InstanceIdBean instanceId;
+
+    @Inject
+    RequestIdBean requestIdBean;
+
+    @Inject
+    SessionIdBean sessionIdBean;
+
+    @Override
+    public void filter(ContainerRequestContext requestCtx, ContainerResponseContext responseCtx) {
+        MultivaluedMap<String, Object> headers = responseCtx.getHeaders();
+        headers.add("x-count", getAndIncIndex());
+        headers.add("x-session", sessionIdBean.getSessionId());
+        headers.add("x-request", requestIdBean.getRequestId());
+        headers.add("x-instance", instanceId.getInstanceId());
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/SessionResource.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/SessionResource.java
@@ -1,0 +1,15 @@
+package io.quarkus.qe.spring.data;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+
+@Path("/session")
+public class SessionResource {
+    @PUT
+    @Path("/invalidate")
+    public void invalidate(final @Context HttpServletRequest req) {
+        req.getSession().invalidate();
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/AppConfiguration.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/AppConfiguration.java
@@ -1,0 +1,43 @@
+package io.quarkus.qe.spring.data.configuration;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.enterprise.inject.spi.CDI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+public class AppConfiguration {
+
+    private AtomicInteger counter = new AtomicInteger(0);
+
+    @Bean
+    @Scope(scopeName = "prototype")
+    public CounterBean produceCounterBean() {
+        return new CounterBean(counter.getAndIncrement());
+    }
+
+    @Bean
+    @Scope(scopeName = "singleton")
+    public InstanceIdBean produceInstanceIdBean() {
+        return new InstanceIdBean(UUID.randomUUID().toString());
+    }
+
+    @Bean
+    @Scope(scopeName = "request")
+    public RequestIdBean produceRequestIdBean(InstanceIdBean instanceId) {
+        return new RequestIdBean(UUID.randomUUID().toString(), instanceId.getInstanceId());
+    }
+
+    @Bean
+    @Scope(scopeName = "session")
+    public SessionIdBean sessionIdBean(InstanceIdBean instanceId) {
+        return new SessionIdBean(UUID.randomUUID().toString(), instanceId.getInstanceId());
+    }
+
+    public static int getAndIncIndex() {
+        CounterBean counter = CDI.current().select(CounterBean.class).get();
+        return counter.getAmount();
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/CounterBean.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/CounterBean.java
@@ -1,0 +1,14 @@
+package io.quarkus.qe.spring.data.configuration;
+
+public class CounterBean {
+
+    private final int amount;
+
+    protected CounterBean(int count) {
+        this.amount = count;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/InstanceIdBean.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/InstanceIdBean.java
@@ -1,0 +1,14 @@
+package io.quarkus.qe.spring.data.configuration;
+
+public class InstanceIdBean {
+
+    private final String instanceId;
+
+    protected InstanceIdBean(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/RequestIdBean.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/RequestIdBean.java
@@ -1,0 +1,15 @@
+package io.quarkus.qe.spring.data.configuration;
+
+public class RequestIdBean {
+
+    private final String requestId;
+
+    public RequestIdBean(String requestId, String instanceId) {
+        this.requestId = String.format("%s_%s", instanceId, requestId);
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/SessionIdBean.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/configuration/SessionIdBean.java
@@ -1,0 +1,14 @@
+package io.quarkus.qe.spring.data.configuration;
+
+public class SessionIdBean {
+
+    private final String sessionId;
+
+    public SessionIdBean(String sessionId, String instanceId) {
+        this.sessionId = String.format("%s_%s", instanceId, sessionId);
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Address.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Address.java
@@ -1,0 +1,48 @@
+package io.quarkus.qe.spring.data.model;
+
+import java.util.List;
+import javax.json.bind.annotation.JsonbTransient;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "address")
+public class Address {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String zipCode;
+
+    @JsonbTransient
+    @OneToMany(mappedBy = "publisherAddress")
+    private List<Book> books;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(String zipCode) {
+        this.zipCode = zipCode;
+    }
+
+    public List<Book> getBooks() {
+        return books;
+    }
+
+    public void setBooks(List<Book> books) {
+        this.books = books;
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Animal.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Animal.java
@@ -1,0 +1,56 @@
+package io.quarkus.qe.spring.data.model;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+// issue QUARKUS-525
+@MappedSuperclass
+public class Animal {
+
+    @Id
+    @GeneratedValue
+    private long id;
+
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime birthDay;
+
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime died;
+
+    private String deathReason;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getBirthDay() {
+        return birthDay;
+    }
+
+    public void setBirthDay(LocalDateTime birthDay) {
+        this.birthDay = birthDay;
+    }
+
+    public LocalDateTime getDied() {
+        return died;
+    }
+
+    public void setDied(LocalDateTime died) {
+        this.died = died;
+    }
+
+    public String getDeathReason() {
+        return deathReason;
+    }
+
+    public void setDeathReason(String deathReason) {
+        this.deathReason = deathReason;
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Book.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Book.java
@@ -1,16 +1,22 @@
-package io.quarkus.qe.spring.data;
+package io.quarkus.qe.spring.data.model;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class Book extends NamedEntity {
-
+    @Id
     private Integer bid;
 
     private Integer publicationYear;
 
     private Long isbn;
+
+    @ManyToOne(targetEntity=Address.class)
+    @JoinColumn(name = "addressId")
+    private Address publisherAddress;
 
     public Book() {
     }
@@ -21,7 +27,6 @@ public class Book extends NamedEntity {
         this.publicationYear = publicationYear;
     }
 
-    @Id
     public Integer getBid() {
         return bid;
     }
@@ -44,5 +49,13 @@ public class Book extends NamedEntity {
 
     public void setIsbn(Long isbn) {
         this.isbn = isbn;
+    }
+
+    public Address getPublisherAddress() {
+        return publisherAddress;
+    }
+
+    public void setPublisherAddress(Address publisherAddress) {
+        this.publisherAddress = publisherAddress;
     }
 }

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Cat.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Cat.java
@@ -1,15 +1,9 @@
-package io.quarkus.qe.spring.data;
+package io.quarkus.qe.spring.data.model;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 
 @Entity
-public class Cat {
-
-    @Id
-    @GeneratedValue
-    public Long id;
+public class Cat extends Mammal{
 
     private String breed;
 
@@ -23,10 +17,6 @@ public class Cat {
     public Cat(String breed, String color) {
         this.breed = breed;
         this.color = color;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public String getBreed() {

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Mammal.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Mammal.java
@@ -1,0 +1,9 @@
+package io.quarkus.qe.spring.data.model;
+
+import javax.persistence.MappedSuperclass;
+
+// issue QUARKUS-525
+@MappedSuperclass
+public class Mammal extends Animal {
+
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/NamedEntity.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/NamedEntity.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.spring.data;
+package io.quarkus.qe.spring.data.model;
 
 import javax.persistence.MappedSuperclass;
 

--- a/601-spring-data-primitive-types/src/main/resources/import.sql
+++ b/601-spring-data-primitive-types/src/main/resources/import.sql
@@ -1,12 +1,14 @@
-INSERT INTO book(bid, name, publicationYear, isbn) VALUES (1, 'Sapiens' , 2011, 9789295055025);
-INSERT INTO book(bid, name, publicationYear, isbn) VALUES (2, 'Homo Deus' , 2015, 9789295055026);
-INSERT INTO book(bid, name, publicationYear, isbn) VALUES (3, 'Enlightenment Now' , 2018, 9789295055027);
-INSERT INTO book(bid, name, publicationYear, isbn) VALUES (4, 'Factfulness' , 2018, 9789295055028);
-INSERT INTO book(bid, name, publicationYear, isbn) VALUES (5, 'Sleepwalkers' , 2012, 9789295055029);
-INSERT INTO book(bid, name, publicationYear, isbn) VALUES (6, 'The Silk Roads' , 2015, 9789295055020);
+INSERT INTO address(id, zipCode) VALUES (1, '28080');
 
-INSERT INTO cat(id, color, breed, distinctive) VALUES (1, 'Grey', 'Scottish Fold', true);
-INSERT INTO cat(id, color, breed, distinctive) VALUES (2, 'Grey', 'Persian', true);
-INSERT INTO cat(id, color, breed, distinctive) VALUES (3, 'White', 'Turkish Angora', true);
-INSERT INTO cat(id, color, breed, distinctive) VALUES (4, null , 'British Shorthair', false );
-INSERT INTO cat(id, color, breed, distinctive) VALUES (5, 'Black' , 'Bombay Cat', true);
+INSERT INTO book(bid, name, publicationYear, isbn, addressId) VALUES (1, 'Sapiens' , 2011, 9789295055025, 1);
+INSERT INTO book(bid, name, publicationYear, isbn, addressId) VALUES (2, 'Homo Deus' , 2015, 9789295055026, 1);
+INSERT INTO book(bid, name, publicationYear, isbn, addressId) VALUES (3, 'Enlightenment Now' , 2018, 9789295055027, 1);
+INSERT INTO book(bid, name, publicationYear, isbn, addressId) VALUES (4, 'Factfulness' , 2018, 9789295055028, 1);
+INSERT INTO book(bid, name, publicationYear, isbn, addressId) VALUES (5, 'Sleepwalkers' , 2012, 9789295055029, 1);
+INSERT INTO book(bid, name, publicationYear, isbn, addressId) VALUES (6, 'The Silk Roads' , 2015, 9789295055020, 1);
+
+INSERT INTO cat(id, color, breed, distinctive, birthDay, died, deathReason) VALUES (1, 'Grey', 'Scottish Fold', true, '2016-06-22 19:10:25-07', null, null);
+INSERT INTO cat(id, color, breed, distinctive, birthDay, died, deathReason) VALUES (2, 'Grey', 'Persian', true, '2018-06-22 19:10:25-07', null, null);
+INSERT INTO cat(id, color, breed, distinctive, birthDay, died, deathReason) VALUES (3, 'White', 'Turkish Angora', true, '2019-06-22 19:10:25-07', null, null);
+INSERT INTO cat(id, color, breed, distinctive, birthDay, died, deathReason) VALUES (4, null , 'British Shorthair', false, '2020-01-22 19:10:25-07', '2020-01-22 19:10:25-07', 'covid19');
+INSERT INTO cat(id, color, breed, distinctive, birthDay, died, deathReason) VALUES (5, 'Black' , 'Bombay Cat', true, '2020-02-22 19:10:25-07', '2020-03-22 19:10:25-07', 'covid19');

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/BookResourceTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/BookResourceTest.java
@@ -1,10 +1,18 @@
 package io.quarkus.qe.spring.data;
 
+import io.quarkus.qe.spring.data.model.Book;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.when;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.Matchers.empty;
 
 @QuarkusTest
 public class BookResourceTest {
@@ -35,5 +43,16 @@ public class BookResourceTest {
         when().get("/book/customPublicationIsbnObject/2").then()
                 .statusCode(200)
                 .body(is("9789295055026"));
+    }
+
+    // QUARKUS-525
+    @Test
+    void testFindBooksByPublisherZipCode() {
+        Response response = when().get("/book/publisher/zipcode/28080").then()
+                .statusCode(200).contentType(ContentType.JSON).extract().response();
+
+        List<Book> books = Arrays.asList(response.getBody().as(Book[].class));
+        assertThat(books, is(not(empty())));
+        books.stream().forEach(book -> assertThat(book.getPublisherAddress().getZipCode(), is("28080")));
     }
 }

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CatResourceTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CatResourceTest.java
@@ -1,14 +1,19 @@
 package io.quarkus.qe.spring.data;
 
+import io.quarkus.qe.spring.data.model.Cat;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.when;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 @QuarkusTest
 public class CatResourceTest {
-
     @Test
     void testCustomFindPublicationYearObjectBoolean() {
         when().get("/cat/customFindDistinctiveObject/2").then()
@@ -20,5 +25,15 @@ public class CatResourceTest {
         when().get("/cat/customFindDistinctivePrimitive/2").then()
                 .statusCode(200)
                 .body(is("true"));
+    }
+    // QUARKUS-532
+    @Test
+    void testFindCatsByDeathReason() {
+        Response response = when().get("/cat/findCatsByMappedSuperclassField/covid19").then()
+                .statusCode(200)
+                .contentType(ContentType.JSON).extract().response();
+
+        List<Cat> cats = Arrays.asList(response.getBody().as(Cat[].class));
+        cats.stream().forEach(cat -> assertThat(cat.getDeathReason(), is("covid19")));
     }
 }

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersIT.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.spring.data;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class CommonsHeadersIT extends CommonsHeadersTest {
+}

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersTest.java
@@ -1,0 +1,92 @@
+package io.quarkus.qe.spring.data;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+
+@QuarkusTest
+public class CommonsHeadersTest {
+    // QUARKUS-547
+    @Test
+    @DisplayName("prototype scope: x-count header must be equal to request amount")
+    void testRequestAmount(){
+        Set<String> xCount = new HashSet<>();
+
+        for(int index = 0; index < 3; index++){
+            Headers headers =  when().get("/cat/customFindDistinctivePrimitive/2").headers();
+            xCount.addAll(headers.getValues("x-count"));
+        }
+
+        assertThat("Unexpected x-count header value(Spring Prototype Scope). Must be the same as HTTP request amount.", xCount.size(), is(3));
+    }
+    // QUARKUS-547
+    @Test
+    @DisplayName("Singleton scope: x-instance-id header must be the same")
+    void testInstanceId(){
+        Set<String> instanceIds = new HashSet<>();
+        for(int index = 0; index < 3; index++){
+            Headers headers =  when().get("/cat/customFindDistinctivePrimitive/2").headers();
+            instanceIds.addAll(headers.getValues("x-instance"));
+        }
+
+        assertThat("Unexpected x-instance header value(Spring Singleton Scope). Must be 1", instanceIds.size(), is(1));
+    }
+    // QUARKUS-547
+    @Test
+    @DisplayName("request scope: x-request header must be equal to request amount")
+    public void testRequestScope() {
+        Set<String> requestIds = new HashSet<>();
+        for(int index = 0; index < 3; index++){
+            Headers headers =  when().get("/cat/customFindDistinctivePrimitive/2").headers();
+            requestIds.addAll(headers.getValues("x-request"));
+        }
+
+        assertThat("Unexpected x-request header value(Spring Request Scope). Must be the same as HTTP request amount.", requestIds.size(), is(3));
+    }
+    // QUARKUS-547
+    @Test
+    @DisplayName("session scope")
+    public void testSessionScope(){
+        final Response first = when().get("/cat/customFindDistinctivePrimitive/2");
+        final String sessionId = first.sessionId();
+        Headers headers = RestAssured.given()
+                .sessionId(sessionId)
+                .get("/cat/customFindDistinctivePrimitive/2")
+                .headers();
+        String msg = "Unexpected x-session header value(Spring Session Scope). Two request from the same http session must have the same x-session header.";
+        assertEquals(first.header("x-session"), headers.getValue("x-session"), msg);
+
+        headers = RestAssured.given()
+                .sessionId(sessionId)
+                .get("/cat/customFindDistinctivePrimitive/2")
+                .headers();
+
+        assertEquals(first.header("x-session"), headers.getValue("x-session"), msg);
+
+        RestAssured.given()
+                .sessionId(sessionId)
+                .when()
+                .put("/session/invalidate")
+                .then();
+
+        Response second  = RestAssured.given()
+                .sessionId(sessionId)
+                .get("/cat/customFindDistinctivePrimitive/2");
+
+        assertNotEquals( first.header("x-session"), second.header("x-session"), "First http session can't be the same as second http session");
+        assertNotEquals( sessionId, second.sessionId(), "(Spring Session scope) Two request from different sessions must have different x-session header.");
+    }
+}


### PR DESCRIPTION
Issues References:
-----------------------------
[Fix spring-data-jpa field lookup with layered @MappedSuperclasses](https://issues.redhat.com/browse/QUARKUS-532)
[Make embedded fields with camel-case work in Spring Data JPA repositories](https://issues.redhat.com/browse/QUARKUS-525)
[Spring's @Scope#scopeName is now taken into account](https://issues.redhat.com/browse/QUARKUS-547)

### Fix spring-data-jpa field lookup with layered @MappedSuperclasses

We have added a "super" structure over the existing Cat entity. With the current implementation Cats extends Mammal and mammal are animals.

### Make embedded fields with camel-case work in Spring Data JPA repositories

We've created a query over an embedded camelCase field.

### Spring's @Scope#scopeName is now taken into account

We've created an HTTP Request filter in order to add headers to the response:

- x-session: Keep the same value per HTTP session
- x-count: count the number of requests
- x-request: increase his value per request
- x-instance: represents the instance ID. Must be a unique per pod. 
