### PR TITLE
fix: remove quarkus.package.type = none from pom.xml

### DIFF
--- a/302-quarkus-vertx-jwt/README.md
+++ b/302-quarkus-vertx-jwt/README.md
@@ -48,7 +48,8 @@ Quarkus / Vertx JWT (AuthN/Z) exploratory testing
 * AuthN
     * Validate JWT token: iss, ext, iat, aud
     * Validate JWT signature
-* AuthZ (pending)
+* AuthZ
+    * Validate that Vertx User belongs to the admin group
 * Quarkus Vertx Reactive Routes
 * OpenAPI from static yaml
 * Reactive Redis

--- a/302-quarkus-vertx-jwt/pom.xml
+++ b/302-quarkus-vertx-jwt/pom.xml
@@ -37,18 +37,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>native</id>
-      <activation>
-        <property>
-          <name>native</name>
-        </property>
-      </activation>
-      <properties>
-        <quarkus.package.type>none</quarkus.package.type>
-      </properties>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
A valid `quarkus.package.type` must be provided. 

Error: [error]: Build step io.quarkus.deployment.pkg.steps.PackageTypeVerificationBuildStep#verify threw an exception: java.lang.IllegalStateException: Unknown packaging type none known types are [fast-jar, legacy, native, jar, uber-jar, mutable-jar]

**Doc:** [Valid package types](https://quarkus.io/guides/all-config#quarkus-core_quarkus.package.type)