### PR TITLE
vertx/jwt-redis move on to quay.io docker registry

### DIFF
--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/resources/RedisResource.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/resources/RedisResource.java
@@ -14,7 +14,8 @@ public class RedisResource implements QuarkusTestResourceLifecycleManager {
     @Override
     public Map<String, String> start() {
 
-        redisContainer = new GenericContainer(DockerImageName.parse("redis:5.0.3-alpine")).withExposedPorts(6379);
+        redisContainer = new GenericContainer(DockerImageName.parse("quay.io/bitnami/redis:6.0"))
+                .withEnv("ALLOW_EMPTY_PASSWORD", "yes").withExposedPorts(6379);
         redisContainer.start();
 
         String redisConPath = String.format("redis://%s:%d", redisContainer.getHost(), redisContainer.getFirstMappedPort());

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
     <testcontainers.version>1.15.0</testcontainers.version>
     <strimzi.testcontainers.version>0.20.0</strimzi.testcontainers.version>
     <wiremock.version>2.27.2</wiremock.version>
-    <bcpkix-jdk15on.version>1.68</bcpkix-jdk15on.version>
     <apicurio-registry-utils-serde.version>1.2.2.Final</apicurio-registry-utils-serde.version>
     <confluent.kafka-avro-serializer.version>6.0.0</confluent.kafka-avro-serializer.version>
 
@@ -90,11 +89,6 @@
         <groupId>io.confluent</groupId>
         <artifactId>kafka-avro-serializer</artifactId>
         <version>${confluent.kafka-avro-serializer.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
-        <version>${bcpkix-jdk15on.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Vertx/jwt-redis: move on to quay.io docker registry.