### PR TITLE
Add micrometer scenarios

### DIFF
--- a/015-quarkus-micrometer/README.md
+++ b/015-quarkus-micrometer/README.md
@@ -1,0 +1,8 @@
+Module that covers the Micrometer extension usage via `MeterRegistry` and `MicroProfile API` approaches. Both will use a counter metrics for testing purposes. 
+
+The `MeterRegistry` approach includes three scenarios: 
+- `simple`: single call will increment the counter.
+- `forloop`: will increment the counter a number of times.
+- `forloop parallel`: will increment the counter a number of times using a parallel flow.
+
+The `MicroProfile API` approach will include only the `simple` scenario.   

--- a/015-quarkus-micrometer/pom.xml
+++ b/015-quarkus-micrometer/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>beefy-scenarios</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>015-quarkus-micrometer</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/015-quarkus-micrometer/src/main/java/io/quarkus/qe/UsingMicroProfilePingPongResource.java
+++ b/015-quarkus-micrometer/src/main/java/io/quarkus/qe/UsingMicroProfilePingPongResource.java
@@ -1,0 +1,21 @@
+package io.quarkus.qe;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+@Path("/using-microprofile-pingpong")
+public class UsingMicroProfilePingPongResource {
+
+    private static final String PING_PONG = "ping pong";
+
+    @GET
+    @Counted(name = "simple_mp", absolute = true)
+    @Produces(MediaType.TEXT_PLAIN)
+    public String simpleScenario() {
+        return PING_PONG;
+    }
+}

--- a/015-quarkus-micrometer/src/main/java/io/quarkus/qe/UsingRegistryPingPongResource.java
+++ b/015-quarkus-micrometer/src/main/java/io/quarkus/qe/UsingRegistryPingPongResource.java
@@ -1,0 +1,52 @@
+package io.quarkus.qe;
+
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Path("/using-registry-pingpong")
+public class UsingRegistryPingPongResource {
+
+    private static final String PING_PONG = "ping pong";
+
+    @Inject
+    MeterRegistry registry;
+
+    @GET
+    @Path("/simple_registry")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String simpleScenario() {
+        incrementCounter("simple_registry");
+
+        return PING_PONG;
+    }
+
+    @GET
+    @Path("/forloop")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String iterativeScenario(@QueryParam("count") int count) {
+        IntStream.range(0, count).forEach(i -> incrementCounter("forloop"));
+
+        return PING_PONG;
+    }
+
+    @GET
+    @Path("/forloopparallel")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String iterativeParallelScenario(@QueryParam("count") int count) {
+        IntStream.range(0, count).parallel().forEach(i -> incrementCounter("forloopparallel"));
+
+        return PING_PONG;
+    }
+
+    private void incrementCounter(String name) {
+        registry.counter(name).increment();
+    }
+}

--- a/015-quarkus-micrometer/src/main/resources/application.properties
+++ b/015-quarkus-micrometer/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Quarkus
+quarkus.http.port=8081
+
+# MP Integration
+quarkus.micrometer.binder.mp-metrics.enabled=true

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeUsingMicroProfilePingPongResourceIT.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeUsingMicroProfilePingPongResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeUsingMicroProfilePingPongResourceIT extends UsingMicroProfilePingPongResourceTest {
+
+}

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeUsingRegistryPingPongResourceIT.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeUsingRegistryPingPongResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeUsingRegistryPingPongResourceIT extends UsingRegistryPingPongResourceTest {
+
+}

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/UsingMicroProfilePingPongResourceTest.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/UsingMicroProfilePingPongResourceTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class UsingMicroProfilePingPongResourceTest {
+
+    private static final String PING_PONG_ENDPOINT = "/using-microprofile-pingpong";
+    private static final String COUNTER_FORMAT = "simple_mp_total{scope=\"application\",} %s.0";
+
+    @Test
+    public void testShouldReturnCountOne() {
+        whenCallPingPong();
+        thenCounterIs(1);
+    }
+
+    private void whenCallPingPong() {
+        given()
+                .when().get(PING_PONG_ENDPOINT)
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is("ping pong"));
+    }
+
+    private void thenCounterIs(int expectedCounter) {
+        when().get("/q/metrics").then()
+                .statusCode(200)
+                .body(containsString(String.format(COUNTER_FORMAT, expectedCounter)));
+    }
+}

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/UsingRegistryPingPongResourceTest.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/UsingRegistryPingPongResourceTest.java
@@ -1,0 +1,69 @@
+package io.quarkus.qe;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class UsingRegistryPingPongResourceTest {
+
+    private static final String PING_PONG_ENDPOINT = "/using-registry-pingpong/";
+    private static final String SIMPLE_SCENARIO = "simple_registry";
+    private static final String FORLOOP_SCENARIO = "forloop";
+    private static final String FORLOOP_PARALLEL_SCENARIO = "forloopparallel";
+    private static final String COUNTER_FORMAT = "%s_total %s.0";
+    private static final String NO_QUERY_PARAMS = null;
+
+    private String currentScenario;
+
+    @Test
+    public void testSimpleScenarioShouldReturnCountOne() {
+        whenCallPingPongScenario(SIMPLE_SCENARIO);
+        thenCounterIs(1);
+    }
+
+    @Test
+    public void testIterativeScenarioShouldReturnCountOne() {
+        whenCallPingPongScenario(FORLOOP_SCENARIO, countQuery(50));
+        thenCounterIs(50);
+    }
+
+    @Test
+    public void testIterativeParallelScenarioShouldReturnCountOne() {
+        whenCallPingPongScenario(FORLOOP_PARALLEL_SCENARIO, countQuery(500));
+        thenCounterIs(500);
+    }
+
+    private void whenCallPingPongScenario(String scenario) {
+        whenCallPingPongScenario(scenario, NO_QUERY_PARAMS);
+    }
+
+    private void whenCallPingPongScenario(String scenario, String queryParams) {
+        currentScenario = scenario;
+        String path = PING_PONG_ENDPOINT + scenario;
+        if (queryParams != null) {
+            path += "?" + queryParams;
+        }
+
+        given()
+                .when().get(path)
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is("ping pong"));
+    }
+
+    private void thenCounterIs(int expectedCounter) {
+        when().get("/q/metrics").then()
+                .statusCode(200)
+                .body(containsString(String.format(COUNTER_FORMAT, currentScenario, expectedCounter)));
+    }
+
+    private static final String countQuery(int count) {
+        return "count=" + count;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
       <module>012-quarkus-kafka-streams</module>
       <module>013-quarkus-oidc-restclient</module>
       <module>014-quarkus-panache-with-transactions-xa</module>
+      <module>015-quarkus-micrometer</module>
       <module>101-javaee-like-getting-started</module>
       <module>201-large-static-content</module>
       <module>300-quarkus-vertx-webClient</module>


### PR DESCRIPTION
Module that covers the Micrometer extension usage via `MeterRegistry` and `MicroProfile API` approaches. Both will use a counter metrics for testing purposes. 

The `MeterRegistry` approach includes three scenarios: 
- `simple`: single call will increment the counter.
- `forloop`: will increment the counter a number of times.
- `forloop parallel`: will increment the counter a number of times using a parallel flow.

The `MicroProfile API` approach will include only the `simple` scenario.   

Note that more complex scenarios such as the integration with either Kafka and Prometheus are out of scope for this PR.