### PR TITLE
Add Http Server Metrics scenario

### DIFF
--- a/015-quarkus-micrometer/README.md
+++ b/015-quarkus-micrometer/README.md
@@ -5,4 +5,6 @@ The `MeterRegistry` approach includes three scenarios:
 - `forloop`: will increment the counter a number of times.
 - `forloop parallel`: will increment the counter a number of times using a parallel flow.
 
-The `MicroProfile API` approach will include only the `simple` scenario.   
+The `MicroProfile API` approach will include only the `simple` scenario.
+
+Moreover, we also cover the `HTTP Server` metrics in order to verify the `count`, `sum` and `count` metrics work as expected.

--- a/015-quarkus-micrometer/src/main/java/io/quarkus/qe/WithoutCustomMetricsPingPongResource.java
+++ b/015-quarkus-micrometer/src/main/java/io/quarkus/qe/WithoutCustomMetricsPingPongResource.java
@@ -1,0 +1,18 @@
+package io.quarkus.qe;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/without-metrics-pingpong")
+public class WithoutCustomMetricsPingPongResource {
+
+    private static final String PING_PONG = "ping pong";
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String simpleScenario() {
+        return PING_PONG;
+    }
+}

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/HttpServerMetricsTest.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/HttpServerMetricsTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.qe;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class HttpServerMetricsTest {
+
+    private static final List<String> HTTP_SERVER_REQUESTS_METRICS_SUFFIX = Arrays.asList("count", "sum", "max");
+
+    private static final String HTTP_SERVER_REQUESTS_METRICS_FORMAT = "http_server_requests_seconds_%s{method=\"GET\",outcome=\"SUCCESS\",status=\"200\",uri=\"%s\",}";
+    private static final String PING_PONG_ENDPOINT = "/without-metrics-pingpong";
+
+    @Test
+    public void testHttpServerRequestsCountShouldBeRegistered() {
+        thenHttpServerRequestsMetricsAreNotPresent();
+
+        whenCallPingPong();
+        thenHttpServerRequestsMetricsArePresent();
+    }
+
+    private void whenCallPingPong() {
+        given()
+                .when().get(PING_PONG_ENDPOINT)
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is("ping pong"));
+    }
+
+    private void thenHttpServerRequestsMetricsAreNotPresent() {
+        String metrics = when().get("/q/metrics").then()
+                .statusCode(HttpStatus.SC_OK).extract().asString();
+
+        for (String metricSuffix : HTTP_SERVER_REQUESTS_METRICS_SUFFIX) {
+            String metric = String.format(HTTP_SERVER_REQUESTS_METRICS_FORMAT, metricSuffix, PING_PONG_ENDPOINT);
+            assertFalse(metrics.contains(metric), "Unexpected metric found: " + metric + ". Metrics: " + metrics);
+        }
+    }
+
+    private void thenHttpServerRequestsMetricsArePresent() {
+        String metrics = when().get("/q/metrics").then()
+                .statusCode(HttpStatus.SC_OK).extract().asString();
+
+        for (String metricSuffix : HTTP_SERVER_REQUESTS_METRICS_SUFFIX) {
+            String metric = String.format(HTTP_SERVER_REQUESTS_METRICS_FORMAT, metricSuffix, PING_PONG_ENDPOINT);
+            assertTrue(metrics.contains(metric), "Expected metric not found: " + metric + ". Metrics: " + metrics);
+        }
+    }
+}

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeHttpServerMetricsIT.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeHttpServerMetricsIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeHttpServerMetricsIT extends HttpServerMetricsTest {
+
+}

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/UsingMicroProfilePingPongResourceTest.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/UsingMicroProfilePingPongResourceTest.java
@@ -31,7 +31,7 @@ public class UsingMicroProfilePingPongResourceTest {
 
     private void thenCounterIs(int expectedCounter) {
         when().get("/q/metrics").then()
-                .statusCode(200)
+                .statusCode(HttpStatus.SC_OK)
                 .body(containsString(String.format(COUNTER_FORMAT, expectedCounter)));
     }
 }

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/UsingRegistryPingPongResourceTest.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/UsingRegistryPingPongResourceTest.java
@@ -59,7 +59,7 @@ public class UsingRegistryPingPongResourceTest {
 
     private void thenCounterIs(int expectedCounter) {
         when().get("/q/metrics").then()
-                .statusCode(200)
+                .statusCode(HttpStatus.SC_OK)
                 .body(containsString(String.format(COUNTER_FORMAT, currentScenario, expectedCounter)));
     }
 


### PR DESCRIPTION
These metrics can be disabled with `https://quarkus.io/guides/micrometer#quarkus-micrometer_quarkus.micrometer.binder.vertx.enabled`. I've already reported an issue because it's the HTTP server metrics, instead of purely vertx metrics: https://github.com/quarkusio/quarkus/issues/14745