### PR TITLE
Bump testcontainers version to 1.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
-    <testcontainers.version>1.15.0</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
     <strimzi.testcontainers.version>0.20.0</strimzi.testcontainers.version>
     <wiremock.version>2.27.2</wiremock.version>
     <apicurio-registry-utils-serde.version>1.2.2.Final</apicurio-registry-utils-serde.version>


### PR DESCRIPTION
Bump testcontainers version to 1.15.1

We had failure https://github.com/quarkus-qe/beefy-scenarios/actions/runs/535412868 in nightly runs.
This should be fixed in 1.15.1.

We do not have so many modules as in QS so I'm not afraid of the stuck threads / execution here.