### PR TITLE
Remove Amazon Lambda Common due to legacy package

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -393,10 +393,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-kms</artifactId>
         </dependency>
-        <dependency>
+        <!-- The Amazon Lambda extensions is not compatible with uber-jar package type.
+         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-lambda-common</artifactId>
-        </dependency>
+        </dependency> 
+        -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-amazon-s3</artifactId>


### PR DESCRIPTION
The build was failing with the next exception:

```
[error]: Build step io.quarkus.deployment.pkg.steps.JarResultBuildStep#buildRunnerJar threw an exception: java.lang.RuntimeException: Extensions with conflicting package types. One extension requires uber-jar another requires legacy format
```

The extension that was using the legacy package is amazon-lambda-common and hence removing it.