### PR TITLE
Use quickly parameter for faster Quarkus builds

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus master
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B -s .github/mvn-settings.xml clean install -DskipTests -DskipITs
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B -s .github/mvn-settings.xml clean install -Dquickly
       - name: Test in JVM mode
         run: |
           mvn -V -B -s .github/mvn-settings.xml clean test


### PR DESCRIPTION
The quickly property is being used in the daily workflows. 

Note that there is a way to make the Quarkus build even faster:

```
git clone https://github.com/quarkusio/quarkus.git && cd quarkus 
&& mvn -B -s .github/mvn-settings.xml clean install -Dquickly -f bom/application 
&& mvn -B -s .github/mvn-settings.xml clean install -Dquickly -f bom/test 
&& mvn -B -s .github/mvn-settings.xml clean install -Dquickly -f build-parent 
&& mvn -B -s .github/mvn-settings.xml clean install -Dquickly -f core 
&& mvn -B -s .github/mvn-settings.xml clean install -Dquickly -f extensions 
&& mvn -B -s .github/mvn-settings.xml clean install -Dquickly -f test-framework
```

I've tested the above command and improves the time build from 15 min to 5 min. So, it works like a charm, but it's ugly like a ñu and fragile like a pencil, that's why I didn't use it in the end. Still, let me know if you prefer this way. 