### PR TITLE
Add scenario for runtime properties

### DIFF
--- a/018-quarkus-runtime-properties/README.md
+++ b/018-quarkus-runtime-properties/README.md
@@ -1,0 +1,2 @@
+Module that covers the runtime configuration to ensure the changes take effect. The configuration that is covered is:
+- Allow disabling/enabling `Swagger/GraphQL/Heatlh/OpenAPI` endpoints on DEV, JVM and Native modes

--- a/018-quarkus-runtime-properties/pom.xml
+++ b/018-quarkus-runtime-properties/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>beefy-scenarios</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>018-quarkus-runtime-properties</artifactId>
+
+    <dependencies>
+    
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-graphql</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/018-quarkus-runtime-properties/src/main/resources/application.properties
+++ b/018-quarkus-runtime-properties/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+# Quarkus
+quarkus.http.port=8081
+
+# Swagger UI
+quarkus.swagger-ui.enable=true
+quarkus.swagger-ui.always-include=true
+
+# OpenAPI
+quarkus.smallrye-openapi.enable=true
+
+# GraphQL
+quarkus.smallrye-graphql.ui.always-include=true
+quarkus.smallrye-graphql.ui.enable=true
+
+# Health
+quarkus.smallrye-health.ui.always-include=true
+quarkus.smallrye-health.ui.enable=true

--- a/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/BaseTogglablePropertiesTest.java
+++ b/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/BaseTogglablePropertiesTest.java
@@ -1,0 +1,49 @@
+package io.quarkus.qe.toggle;
+
+import static io.restassured.RestAssured.given;
+
+import java.time.Duration;
+
+import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public abstract class BaseTogglablePropertiesTest {
+
+    protected abstract void whenChangeServiceAtRuntime(TogglableServices service, boolean enable);
+
+    @ParameterizedTest
+    @EnumSource(TogglableServices.class)
+    public void shouldBeUpAndRunning(TogglableServices service) {
+        thenServiceIsRunning(service);
+
+        whenDisableServiceAtRuntime(service);
+        thenServiceIsNotRunning(service);
+
+        whenEnableServiceAtRuntime(service);
+        thenServiceIsRunning(service);
+    }
+
+    private void whenDisableServiceAtRuntime(TogglableServices service) {
+        whenChangeServiceAtRuntime(service, false);
+    }
+
+    private void whenEnableServiceAtRuntime(TogglableServices service) {
+        whenChangeServiceAtRuntime(service, true);
+    }
+
+    private void thenServiceIsRunning(TogglableServices service) {
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            given().port(8081).get(service.getEndpoint())
+                    .then().statusCode(HttpStatus.SC_OK);
+        });
+    }
+
+    private void thenServiceIsNotRunning(TogglableServices service) {
+        Awaitility.await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            given().port(8081).get(service.getEndpoint())
+                    .then().statusCode(HttpStatus.SC_NOT_FOUND);
+        });
+    }
+}

--- a/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/TogglablePropertiesOnDevModeTest.java
+++ b/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/TogglablePropertiesOnDevModeTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.qe.toggle;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class TogglablePropertiesOnDevModeTest extends BaseTogglablePropertiesTest {
+
+    private static final String APPLICATION_PROPERTIES = "application.properties";
+
+    @RegisterExtension
+    static final QuarkusDevModeTest app = new QuarkusDevModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(APPLICATION_PROPERTIES, APPLICATION_PROPERTIES));
+
+    @Override
+    protected void whenChangeServiceAtRuntime(TogglableServices service, boolean enable) {
+        app.modifyResourceFile(APPLICATION_PROPERTIES,
+                s -> s.replace(service.getToggleProperty() + "=" + !enable, service.getToggleProperty() + "=" + enable));
+    }
+}

--- a/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/TogglablePropertiesOnJvmModeTest.java
+++ b/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/TogglablePropertiesOnJvmModeTest.java
@@ -1,0 +1,27 @@
+package io.quarkus.qe.toggle;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class TogglablePropertiesOnJvmModeTest extends BaseTogglablePropertiesTest {
+
+    private static final String APPLICATION_PROPERTIES = "application.properties";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest app = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(APPLICATION_PROPERTIES, APPLICATION_PROPERTIES))
+            .setRun(true);
+
+    @Override
+    protected void whenChangeServiceAtRuntime(TogglableServices service, boolean enable) {
+        app.stop();
+        app.setRuntimeProperties(Collections.singletonMap(service.getToggleProperty(), "" + enable));
+        app.start();
+    }
+}

--- a/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/TogglablePropertiesOnNativeModeIT.java
+++ b/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/TogglablePropertiesOnNativeModeIT.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe.toggle;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class TogglablePropertiesOnNativeModeIT extends BaseTogglablePropertiesTest {
+
+    private static final String APPLICATION_PROPERTIES = "application.properties";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest app = new QuarkusProdModeTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource(APPLICATION_PROPERTIES, APPLICATION_PROPERTIES))
+            .setRun(true)
+            .setBuildNative(true);
+
+    @Override
+    protected void whenChangeServiceAtRuntime(TogglableServices service, boolean enable) {
+        app.stop();
+        app.setRuntimeProperties(Collections.singletonMap(service.getToggleProperty(), "" + enable));
+        app.start();
+    }
+}

--- a/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/TogglableServices.java
+++ b/018-quarkus-runtime-properties/src/test/java/io/quarkus/qe/toggle/TogglableServices.java
@@ -1,0 +1,30 @@
+package io.quarkus.qe.toggle;
+
+public enum TogglableServices {
+    SWAGGER("Swagger", "/q/swagger-ui", "quarkus.swagger-ui.enable"),
+    OPENAPI("OpenAPI", "/q/openapi", "quarkus.smallrye-openapi.enable"),
+    GRAPHQL("GraphQL", "/q/graphql-ui", "quarkus.smallrye-graphql.ui.enable"),
+    HEALTH("Health", "/q/health-ui", "quarkus.smallrye-health.ui.enable");
+
+    private final String name;
+    private final String endpoint;
+    private final String toggleProperty;
+
+    TogglableServices(String name, String endpoint, String toggleProperty) {
+        this.name = name;
+        this.endpoint = endpoint;
+        this.toggleProperty = toggleProperty;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getToggleProperty() {
+        return toggleProperty;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
       <module>014-quarkus-panache-with-transactions-xa</module>
       <module>015-quarkus-micrometer</module>
       <module>017-quartz-cluster</module>
+      <module>018-quarkus-runtime-properties</module>
       <module>101-javaee-like-getting-started</module>
       <module>201-large-static-content</module>
       <module>300-quarkus-vertx-webClient</module>
@@ -160,6 +161,7 @@
                 <configuration>
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                   </systemProperties>
                 </configuration>
               </execution>


### PR DESCRIPTION
Module that covers the runtime configuration to ensure the changes take effect. The configuration that is covered is:
- Allow disabling/enabling `Swagger/GraphQL/Heatlh/OpenAPI` endpoints on DEV mode