### PR TITLE
Refactor 303 quarkus vertx sql module

### DIFF
--- a/303-quarkus-vertx-sql/pom.xml
+++ b/303-quarkus-vertx-sql/pom.xml
@@ -52,12 +52,6 @@
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-mongo-client</artifactId>
-            <version>4.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Airline.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Airline.java
@@ -1,17 +1,18 @@
 package io.quarkus.qe.vertx.sql.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import javax.validation.constraints.NotBlank;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(name="Airline", description="Airline entity")
 @RegisterForReflection
@@ -19,12 +20,10 @@ public class Airline extends Record{
 
     private static final String QUALIFIED_CODE_NAME = "iata_code";
     @Schema(description="IATA code")
-    @NotBlank(message="Airline code must be not blank")
     private String code;
 
     private static final String QUALIFIED_NAME_NAME = "name";
     @Schema(description="Airline company name")
-    @NotBlank(message="Airline name must be not blank")
     private String name;
 
     private static final String QUALIFIED_INFANT_PRICE_NAME = "infant_price";

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Airport.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Airport.java
@@ -1,16 +1,17 @@
 package io.quarkus.qe.vertx.sql.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import javax.validation.constraints.NotBlank;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(name="Airport", description="Airport entity")
 @RegisterForReflection
@@ -18,12 +19,10 @@ public class Airport extends Record{
 
     private static final String QUALIFIED_CODE_NAME = "iata_code";
     @Schema(description="IATA code")
-    @NotBlank(message="Airport code must be not blank")
     private String code;
 
     private static final String QUALIFIED_CITY_NAME = "city";
     @Schema(description="City name")
-    @NotBlank(message="Airport city must be not blank")
     private String city;
 
     public Airport(long id, String code, String city) {

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Flight.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/domain/Flight.java
@@ -1,16 +1,17 @@
 package io.quarkus.qe.vertx.sql.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import javax.validation.constraints.NotBlank;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(name="Flight", description="Flight entity")
 @RegisterForReflection
@@ -18,17 +19,14 @@ public class Flight extends Record{
 
     private static final String QUALIFIED_ORIGIN_NAME = "origin";
     @Schema(description="origin")
-    @NotBlank(message="Flight origin must be not blank")
     private String origin;
 
     private static final String QUALIFIED_DESTINATION_NAME = "destination";
     @Schema(description="destination")
-    @NotBlank(message="Flight destination must be not blank")
     private String destination;
 
     private static final String QUALIFIED_AIRLINE_NAME = "flight_code";
     @Schema(description="flightCode")
-    @NotBlank(message="Flight code must be not blank")
     private String flightCode;
 
     private static final String QUALIFIED_PRICE_NAME = "base_price";

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/BasketHandler.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/BasketHandler.java
@@ -1,23 +1,24 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
-import io.quarkus.qe.vertx.sql.domain.Basket;
-import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.qe.vertx.sql.domain.Record;
-import io.quarkus.vertx.web.Body;
-import io.quarkus.vertx.web.Route;
-import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.RoutingContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.validation.Valid;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.qe.vertx.sql.domain.Basket;
+import io.quarkus.qe.vertx.sql.domain.Record;
+import io.quarkus.qe.vertx.sql.services.DbPoolService;
+import io.quarkus.vertx.web.Body;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RouteBase;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
 
 
 @Tag(name = "Basket", description = "Manage your basket")
@@ -32,7 +33,7 @@ public class BasketHandler {
     @Operation(summary = "save basket")
     @APIResponse(responseCode = "201", description = "basket id", content = @Content(mediaType = "application/json", schema = @Schema(type = SchemaType.OBJECT, implementation = Record.class)))
     @Route(methods = HttpMethod.POST, path = "/checkout")
-    void search(@Body @Valid Basket basket, RoutingContext context) {
+    void search(@Body Basket basket, RoutingContext context) {
         basket.save(connection)
                 .onFailure().invoke(context::fail)
                 .subscribe().with(id -> context.response().setStatusCode(201).end(new Record(id).toJsonStringify()));

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/services/DbPoolService.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/services/DbPoolService.java
@@ -1,12 +1,12 @@
 package io.quarkus.qe.vertx.sql.services;
 
-import io.vertx.sqlclient.PropertyKind;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.sqlclient.Pool;
 import io.vertx.mutiny.sqlclient.SqlClientHelper;
-import java.util.stream.Collectors;
+import io.vertx.sqlclient.PropertyKind;
 
 public class DbPoolService extends Pool {
 
@@ -53,7 +53,7 @@ public class DbPoolService extends Pool {
             return tx.preparedQuery("INSERT INTO " + getDatabaseName() + "." + tableName + " (" + fields + ") VALUES (" + values + ")")
                     .execute()
                     .onItem().invoke(r->this.query("SELECT LAST_INSERT_ID();"))
-                    .onItem().transform(id -> (Long)id.getDelegate().property(LAST_INSERTED_ID));
+                    .onItem().transform(id -> (Long) id.getDelegate().property(LAST_INSERTED_ID));
         });
     }
 

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/services/FlightSearchService.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/services/FlightSearchService.java
@@ -1,22 +1,24 @@
 package io.quarkus.qe.vertx.sql.services;
 
-import io.quarkus.qe.vertx.sql.domain.Airline;
-import io.quarkus.qe.vertx.sql.domain.Flight;
-import io.quarkus.qe.vertx.sql.domain.Basket;
-import io.quarkus.qe.vertx.sql.domain.PricingRules;
-import io.quarkus.qe.vertx.sql.domain.QueryFlightSearch;
-import io.quarkus.runtime.StartupEvent;
-import io.smallrye.mutiny.Uni;
+import static io.quarkus.qe.vertx.sql.domain.Airline.codeFromFlight;
+import static io.quarkus.qe.vertx.sql.domain.PricingRules.daysToDepartureFilter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import static io.quarkus.qe.vertx.sql.domain.Airline.codeFromFlight;
-import static io.quarkus.qe.vertx.sql.domain.PricingRules.daysToDepartureFilter;
+import io.quarkus.qe.vertx.sql.domain.Airline;
+import io.quarkus.qe.vertx.sql.domain.Basket;
+import io.quarkus.qe.vertx.sql.domain.Flight;
+import io.quarkus.qe.vertx.sql.domain.PricingRules;
+import io.quarkus.qe.vertx.sql.domain.QueryFlightSearch;
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.mutiny.Uni;
 
 @Singleton
 public class FlightSearchService {
@@ -37,7 +39,7 @@ public class FlightSearchService {
         return Flight.findByOriginDestination(connection, query.from, query.to)
                 .onItem()
                 .transform(flight -> calculatePrice(query, flight))
-                .collectItems().in(ArrayList::new, List::add);
+                .collect().in(ArrayList::new, List::add);
     }
 
     private Basket calculatePrice(QueryFlightSearch query, Flight flight) {

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/Db2PoolTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/Db2PoolTest.java
@@ -1,6 +1,23 @@
 package io.quarkus.qe.vertx.sql.dbpool;
 
-import io.quarkus.arc.profile.IfBuildProfile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.qe.vertx.sql.test.resources.Db2TestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -12,23 +29,6 @@ import io.vertx.mutiny.core.Vertx;
 import io.vertx.mutiny.db2client.DB2Pool;
 import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.inject.Inject;
-import javax.inject.Named;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @TestProfile(Db2TestProfile.class)

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresPoolTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/dbpool/PostgresPoolTest.java
@@ -1,48 +1,47 @@
 package io.quarkus.qe.vertx.sql.dbpool;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import io.smallrye.mutiny.Multi;
-import io.vertx.core.Handler;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import io.vertx.mutiny.ext.web.client.HttpResponse;
-import io.vertx.mutiny.sqlclient.Row;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
 import io.vertx.mutiny.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.mutiny.pgclient.PgPool;
+import io.vertx.mutiny.sqlclient.Row;
 import io.vertx.mutiny.sqlclient.RowSet;
-import org.junit.jupiter.api.TestMethodOrder;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @QuarkusTest
 @TestProfile(PostgresqlTestProfile.class)

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/AirlineHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/AirlineHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.Airline;
+package io.quarkus.qe.vertx.sql.handlers.airline;
 
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/Db2AirlineHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/Db2AirlineHandlerTest.java
@@ -1,5 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.Flights;
-
+package io.quarkus.qe.vertx.sql.handlers.airline;
 
 import io.quarkus.qe.vertx.sql.test.resources.Db2TestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -7,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(Db2TestProfile.class)
-public class Db2HandlerTest extends FlightsHandlerTest {
+public class Db2AirlineHandlerTest extends AirlineHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/MysqlAirlineHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/MysqlAirlineHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.airport;
+package io.quarkus.qe.vertx.sql.handlers.airline;
 
 import io.quarkus.qe.vertx.sql.test.resources.MysqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(MysqlTestProfile.class)
-public class MysqlHandlerTest extends AirportHandlerTest {
+public class MysqlAirlineHandlerTest extends AirlineHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/PostgresqlAirlineHandlerIT.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/PostgresqlAirlineHandlerIT.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.airport;
+package io.quarkus.qe.vertx.sql.handlers.airline;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlResource;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
 @QuarkusTestResource(PostgresqlResource.class)
-public class PostgresqlHandlerIT extends AirportHandlerTest {
+public class PostgresqlAirlineHandlerIT extends AirlineHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/PostgresqlAirlineHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airline/PostgresqlAirlineHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.Flights;
+package io.quarkus.qe.vertx.sql.handlers.airline;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(PostgresqlTestProfile.class)
-public class PostgresqlHandlerTest extends FlightsHandlerTest {
+public class PostgresqlAirlineHandlerTest extends AirlineHandlerTest{
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airport/Db2AirportHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airport/Db2AirportHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.PricingRules;
+package io.quarkus.qe.vertx.sql.handlers.airport;
 
 import io.quarkus.qe.vertx.sql.test.resources.Db2TestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(Db2TestProfile.class)
-public class Db2HandlerTest extends PricingRulesHandlerTest {
+public class Db2AirportHandlerTest extends AirportHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airport/MysqlAirportHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airport/MysqlAirportHandlerTest.java
@@ -1,11 +1,10 @@
-package io.quarkus.qe.vertx.sql.handlers.Airline;
+package io.quarkus.qe.vertx.sql.handlers.airport;
 
 import io.quarkus.qe.vertx.sql.test.resources.MysqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
-
 @QuarkusTest
 @TestProfile(MysqlTestProfile.class)
-public class MysqlHandlerTest extends AirlineHandlerTest {
+public class MysqlAirportHandlerTest extends AirportHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airport/PostgresqlAirportHandlerIT.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airport/PostgresqlAirportHandlerIT.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.PricingRules;
+package io.quarkus.qe.vertx.sql.handlers.airport;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlResource;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
 @QuarkusTestResource(PostgresqlResource.class)
-public class PostgresqlHandlerIT extends PricingRulesHandlerTest {
+public class PostgresqlAirportHandlerIT extends AirportHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airport/PostgresqlAirportHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/airport/PostgresqlAirportHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.PricingRules;
+package io.quarkus.qe.vertx.sql.handlers.airport;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(PostgresqlTestProfile.class)
-public class PostgresqlHandlerTest extends PricingRulesHandlerTest {
+public class PostgresqlAirportHandlerTest extends AirportHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/basket/Db2BasketHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/basket/Db2BasketHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.Airline;
+package io.quarkus.qe.vertx.sql.handlers.basket;
 
 import io.quarkus.qe.vertx.sql.test.resources.Db2TestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(Db2TestProfile.class)
-public class Db2HandlerTest extends AirlineHandlerTest {
+public class Db2BasketHandlerTest extends BasketHandlerTest{
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/basket/MysqlBasketHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/basket/MysqlBasketHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.Flights;
+package io.quarkus.qe.vertx.sql.handlers.basket;
 
 import io.quarkus.qe.vertx.sql.test.resources.MysqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(MysqlTestProfile.class)
-public class MysqlHandlerTest extends FlightsHandlerTest {
+public class MysqlBasketHandlerTest extends BasketHandlerTest{
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/basket/PostgresqlBasketHandlerIT.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/basket/PostgresqlBasketHandlerIT.java
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
 @QuarkusTestResource(PostgresqlResource.class)
-public class PostgresqlHandlerIT extends BasketHandlerTest {
+public class PostgresqlBasketHandlerIT extends BasketHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/basket/PostgresqlBasketHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/basket/PostgresqlBasketHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.Airline;
+package io.quarkus.qe.vertx.sql.handlers.basket;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(PostgresqlTestProfile.class)
-public class PostgresqlHandlerTest extends AirlineHandlerTest{
+public class PostgresqlBasketHandlerTest extends BasketHandlerTest{
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/Db2FlightsHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/Db2FlightsHandlerTest.java
@@ -1,4 +1,5 @@
-package io.quarkus.qe.vertx.sql.handlers.basket;
+package io.quarkus.qe.vertx.sql.handlers.flights;
+
 
 import io.quarkus.qe.vertx.sql.test.resources.Db2TestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +7,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(Db2TestProfile.class)
-public class Db2HandlerTest extends BasketHandlerTest{
+public class Db2FlightsHandlerTest extends FlightsHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/FlightsHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/FlightsHandlerTest.java
@@ -1,20 +1,22 @@
-package io.quarkus.qe.vertx.sql.handlers.Flights;
+package io.quarkus.qe.vertx.sql.handlers.flights;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.vertx.sql.domain.Basket;
 import io.quarkus.qe.vertx.sql.domain.Flight;
 import io.quarkus.qe.vertx.sql.domain.QueryFlightSearch;
 import io.restassured.http.ContentType;
-import java.util.Arrays;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class FlightsHandlerTest {
     @Test
@@ -27,6 +29,7 @@ public abstract class FlightsHandlerTest {
                 .statusCode(200)
                 .assertThat().body("size()", is(89));
     }
+
     @Test
     @DisplayName("Retrieve all flights by origin and destination")
     public void retrieveFlightByOriginDestination() {
@@ -43,6 +46,7 @@ public abstract class FlightsHandlerTest {
                 hasProperty("destination", is("CDG"))
         ));
     }
+
     @Test
     @DisplayName("Retrieve infant flights prices")
     public void retrieveInfantFlightPrices() {
@@ -60,6 +64,7 @@ public abstract class FlightsHandlerTest {
                 hasProperty("price", is(15.0))
         ));
     }
+
     @Test
     @DisplayName("Retrieve child flights prices")
     public void retrieveChildFlightPrices() {
@@ -77,6 +82,7 @@ public abstract class FlightsHandlerTest {
                 hasProperty("price", is(233.16))
         ));
     }
+
     @Test
     @DisplayName("Retrieve adult flights prices")
     public void retrieveAdultFlightPrices() {
@@ -94,6 +100,7 @@ public abstract class FlightsHandlerTest {
                 hasProperty("price", is(348.0))
         ));
     }
+
     @Test
     @DisplayName("Retrieve flights prices")
     public void retrieveFlightPrices() {
@@ -113,6 +120,7 @@ public abstract class FlightsHandlerTest {
                 hasProperty("price", is(789.88))
         ));
     }
+
     @Test
     @DisplayName("Retrieve multiple flights prices")
     public void retrieveMultiplesFlightPrices() {
@@ -134,6 +142,7 @@ public abstract class FlightsHandlerTest {
         List<Basket> basket = thenMakeFlightSearchQuery(query, 200,3);
         assertEquals(basket, expectedBasket);
     }
+
     @Test
     @DisplayName("Wrong flight search format")
     public void wrongFlightSearchFormat() {

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/MysqlFlightsHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/MysqlFlightsHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.basket;
+package io.quarkus.qe.vertx.sql.handlers.flights;
 
 import io.quarkus.qe.vertx.sql.test.resources.MysqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(MysqlTestProfile.class)
-public class MysqlHandlerTest extends BasketHandlerTest{
+public class MysqlFlightsHandlerTest extends FlightsHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/PostgresqlFlightsHandlerIT.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/PostgresqlFlightsHandlerIT.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.Airline;
+package io.quarkus.qe.vertx.sql.handlers.flights;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlResource;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
 @QuarkusTestResource(PostgresqlResource.class)
-public class PostgresqlHandlerIT extends AirlineHandlerTest {
+public class PostgresqlFlightsHandlerIT extends FlightsHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/PostgresqlFlightsHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/flights/PostgresqlFlightsHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.airport;
+package io.quarkus.qe.vertx.sql.handlers.flights;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(PostgresqlTestProfile.class)
-public class PostgresqlHandlerTest extends AirportHandlerTest {
+public class PostgresqlFlightsHandlerTest extends FlightsHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/Db2PricingRulesHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/Db2PricingRulesHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.airport;
+package io.quarkus.qe.vertx.sql.handlers.pricing;
 
 import io.quarkus.qe.vertx.sql.test.resources.Db2TestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(Db2TestProfile.class)
-public class Db2HandlerTest extends AirportHandlerTest {
+public class Db2PricingRulesHandlerTest extends PricingRulesHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/MysqlPricingRulesHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/MysqlPricingRulesHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.PricingRules;
+package io.quarkus.qe.vertx.sql.handlers.pricing;
 
 import io.quarkus.qe.vertx.sql.test.resources.MysqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(MysqlTestProfile.class)
-public class MysqlHandlerTest extends PricingRulesHandlerTest {
+public class MysqlPricingRulesHandlerTest extends PricingRulesHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/PostgresqlHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/PostgresqlHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.basket;
+package io.quarkus.qe.vertx.sql.handlers.pricing;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlTestProfile;
 import io.quarkus.test.junit.QuarkusTest;
@@ -6,5 +6,5 @@ import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(PostgresqlTestProfile.class)
-public class PostgresqlHandlerTest extends BasketHandlerTest{
+public class PostgresqlHandlerTest extends PricingRulesHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/PostgresqlPricingRulesHandlerIT.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/PostgresqlPricingRulesHandlerIT.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.Flights;
+package io.quarkus.qe.vertx.sql.handlers.pricing;
 
 import io.quarkus.qe.vertx.sql.test.resources.PostgresqlResource;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -6,6 +6,5 @@ import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
 @QuarkusTestResource(PostgresqlResource.class)
-//@DisabledOnNativeImage("Some issues are under investigation")
-public class PostgresqlHandlerIT extends FlightsHandlerTest {
+public class PostgresqlPricingRulesHandlerIT extends PricingRulesHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/PricingRulesHandlerTest.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/pricing/PricingRulesHandlerTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.qe.vertx.sql.handlers.PricingRules;
+package io.quarkus.qe.vertx.sql.handlers.pricing;
 
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/Db2Resource.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/Db2Resource.java
@@ -1,20 +1,21 @@
 package io.quarkus.qe.vertx.sql.test.resources;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import static io.quarkus.qe.vertx.sql.test.resources.Db2TestProfile.PROFILE;
+
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
+
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
-import static io.quarkus.qe.vertx.sql.test.resources.Db2TestProfile.PROFILE;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class Db2Resource implements QuarkusTestResourceLifecycleManager {
 
-    GenericContainer db2Container;
+    private GenericContainer<?> db2Container;
 
     @Override
     public Map<String, String> start() {
@@ -25,8 +26,9 @@ public class Db2Resource implements QuarkusTestResourceLifecycleManager {
         return config;
     }
 
+    @SuppressWarnings("resource")
     private void defaultDb2Container(Map<String, String> config) {
-        db2Container = new GenericContainer(DockerImageName.parse("quay.io/pjgg/db2:11.5.5.0"))
+        db2Container = new GenericContainer<>(DockerImageName.parse("quay.io/pjgg/db2:11.5.5.0"))
                 .withPrivilegedMode(true)
                 .withEnv("LICENSE", "accept")
                 .withEnv("DB2INST1_PASSWORD", "test")
@@ -49,7 +51,9 @@ public class Db2Resource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public void stop() {
-        if (Objects.nonNull(db2Container)) db2Container.stop();
+        if (db2Container != null) {
+            db2Container.stop();
+        }
     }
 
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/MysqlResource.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/MysqlResource.java
@@ -1,20 +1,20 @@
 package io.quarkus.qe.vertx.sql.test.resources;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import static io.quarkus.qe.vertx.sql.test.resources.MysqlTestProfile.PROFILE;
+
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
+
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
-
-import static io.quarkus.qe.vertx.sql.test.resources.MysqlTestProfile.PROFILE;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class MysqlResource implements QuarkusTestResourceLifecycleManager {
 
-    GenericContainer mysqlContainer;
+    private GenericContainer<?> mysqlContainer;
 
     @Override
     public Map<String, String> start() {
@@ -25,8 +25,9 @@ public class MysqlResource implements QuarkusTestResourceLifecycleManager {
         return config;
     }
 
+    @SuppressWarnings("resource")
     private void defaultMysqlContainer(Map<String, String> config) {
-        mysqlContainer = new GenericContainer(DockerImageName.parse("quay.io/bitnami/mysql:5.7.32"))
+        mysqlContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/mysql:5.7.32"))
                 .withEnv("MYSQL_ROOT_PASSWORD", "test")
                 .withEnv("MYSQL_USER", "test")
                 .withEnv("MYSQL_PASSWORD", "test")
@@ -46,6 +47,8 @@ public class MysqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public void stop() {
-        if (Objects.nonNull(mysqlContainer)) mysqlContainer.stop();
+        if (mysqlContainer != null) {
+            mysqlContainer.stop();
+        }
     }
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/PostgresqlResource.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/PostgresqlResource.java
@@ -1,20 +1,20 @@
 package io.quarkus.qe.vertx.sql.test.resources;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import static io.quarkus.qe.vertx.sql.test.resources.PostgresqlTestProfile.PROFILE;
+
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
+
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
 import org.testcontainers.utility.DockerImageName;
 
-
-import static io.quarkus.qe.vertx.sql.test.resources.PostgresqlTestProfile.PROFILE;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
 
-    GenericContainer postgresContainer;
+    private GenericContainer<?> postgresContainer;
 
     @Override
     public Map<String, String> start() {
@@ -25,8 +25,9 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
         return config;
     }
 
+    @SuppressWarnings("resource")
     private void defaultPostgresContainer(Map<String, String> config) {
-        postgresContainer = new GenericContainer(DockerImageName.parse("quay.io/debezium/postgres:latest"))
+        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/debezium/postgres:latest"))
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_DB", "amadeus")
@@ -43,6 +44,8 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public void stop() {
-        if (Objects.nonNull(postgresContainer)) postgresContainer.stop();
+        if (postgresContainer != null) {
+            postgresContainer.stop();
+        }
     }
 }


### PR DESCRIPTION
I'm planning to implement more scenarios in regards of Route validation:
- Add a custom validator
- Validate responses

Beforehand, this PR aims to make some cleanup with:
- Rename test classes in order to avoid having duplicate class names in different packages
- Remove unnecessary @Valid and validator annotations
- Fix some warnings that my IDE was complaining about