### PR TITLE
Revert "Upgrade native builder image to 21.0-java11"

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.0-java11", "ubi-quarkus-mandrel:21.0-java11" ]
+        image: [ "ubi-quarkus-native-image:20.3.1-java11", "ubi-quarkus-mandrel:20.3-java11" ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.0-java11"]
+        image: [ "ubi-quarkus-native-image:20.3.1-java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -23,7 +23,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus master
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && mvn -B -s .github/mvn-settings.xml clean install -Dquickly
+          git clone https://github.com/gsmet/quarkus.git && cd quarkus && git checkout java-serialization && mvn -B -s .github/mvn-settings.xml clean install -Dquickly
       - name: Test in JVM mode
         run: |
           mvn -V -B -s .github/mvn-settings.xml clean test


### PR DESCRIPTION
This is only intended to verify if this is fixed: https://github.com/quarkusio/quarkus/pull/15145
I could't reproduce this issue locally, so I'm using CI for verifying this.