### PR TITLE
Fix consul test for windows and macos

### DIFF
--- a/019-quarkus-consul/src/test/java/io/quarkus/qe/containers/ConsulContainer.java
+++ b/019-quarkus-consul/src/test/java/io/quarkus/qe/containers/ConsulContainer.java
@@ -1,0 +1,17 @@
+package io.quarkus.qe.containers;
+
+import java.time.Duration;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+public class ConsulContainer extends GenericContainer<ConsulContainer> {
+    private static final int PORT = 8500;
+
+    public ConsulContainer() {
+        super("quay.io/bitnami/consul:1.9.3");
+        waitingFor(new LogMessageWaitStrategy().withRegEx(".*Synced node info.*\\s"));
+        withStartupTimeout(Duration.ofMillis(60000));
+        addFixedExposedPort(PORT, PORT);
+    }
+}

--- a/019-quarkus-consul/src/test/java/io/quarkus/qe/containers/ConsulTestResource.java
+++ b/019-quarkus-consul/src/test/java/io/quarkus/qe/containers/ConsulTestResource.java
@@ -4,14 +4,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.KeyValueClient;
@@ -19,18 +17,12 @@ import com.orbitz.consul.KeyValueClient;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class ConsulTestResource implements QuarkusTestResourceLifecycleManager {
-    private GenericContainer<?> resource;
 
-    @SuppressWarnings("resource")
+    private ConsulContainer resource;
+
     @Override
     public Map<String, String> start() {
-
-        resource = new GenericContainer<>("consul:1.7")
-                .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Node info in sync.*\\s"))
-                .withStartupTimeout(Duration.ofMillis(20000))
-                .withNetworkMode("host")
-                .withCommand("agent -dev");
-
+        resource = new ConsulContainer();
         resource.start();
 
         Consul client = Consul.builder().build();


### PR DESCRIPTION
Using network=host is not compatible with Windows and MacOS.
Using the latest image of Consul allows running consul without network=host, just mapping the port.
