### PR TITLE
Non-appliaction endpoints coverage

### DIFF
--- a/020-quarkus-http-non-application-endpoints/README.md
+++ b/020-quarkus-http-non-application-endpoints/README.md
@@ -1,0 +1,70 @@
+# Scenario 020: Quarkus http non-application endpoints
+
+We have covered the following non-application endpoints:
+
+```
+- /metrics
+    - /metrics/vendor
+    - /metrics/application
+    - /metrics/base
+- /health
+  - /health/live
+  - /health/ready
+  - /health/well
+  - /health/group
+- /openapi
+- /swagger-ui
+```
+
+Scenarios:
+* Relative paths: 
+
+```
+# Application.properties example
+quarkus.http.root-path=/api
+quarkus.http.non-application-root-path=q
+quarkus.http.redirect-to-non-application-root-path=false
+```
+
+Valid request example: `http://localhost:8080/api/q/health`
+
+* Empty non-application root path:
+
+```
+# Application.properties example
+quarkus.http.root-path=/api
+quarkus.http.non-application-root-path=/
+quarkus.http.redirect-to-non-application-root-path=false
+```
+All request will return an HTTP status `404`
+
+* Non-application root path with `slash` base path:
+```
+# Application.properties example
+%emptyRootPath.quarkus.http.root-path=/
+%emptyRootPath.quarkus.http.non-application-root-path=/q
+%emptyRootPath.quarkus.http.redirect-to-non-application-root-path=false
+```
+
+Valid request example: `http://localhost:8080/q/health`
+
+* Defined application base path and non-application root path:
+
+```
+# Application.properties example
+quarkus.http.root-path=/api
+quarkus.http.non-application-root-path=/q
+quarkus.http.redirect-to-non-application-root-path=false
+```
+
+Valid request example: `http://localhost:8080/q/health`
+
+* Backward compatibility (allow redirections):
+
+```
+quarkus.http.root-path=/api
+quarkus.http.non-application-root-path=/q
+quarkus.http.redirect-to-non-application-root-path=true
+```
+
+Valid request example: `http://localhost:8080/api/health`, will be redirected to `http://localhost:8080/q/health`

--- a/020-quarkus-http-non-application-endpoints/pom.xml
+++ b/020-quarkus-http-non-application-endpoints/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>beefy-scenarios</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>020-quarkus-http-non-application-endpoints</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/020-quarkus-http-non-application-endpoints/src/main/java/io/quarkus/qe/http/non_application/endpoint/HelloResource.java
+++ b/020-quarkus-http-non-application-endpoints/src/main/java/io/quarkus/qe/http/non_application/endpoint/HelloResource.java
@@ -1,0 +1,19 @@
+package io.quarkus.qe.http.non_application.endpoint;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class HelloResource {
+    private static final String TEMPLATE = "Hello, %s!";
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String get(@QueryParam("name") @DefaultValue("World") String name) {
+        return String.format(TEMPLATE, name);
+    }
+}

--- a/020-quarkus-http-non-application-endpoints/src/main/resources/application.properties
+++ b/020-quarkus-http-non-application-endpoints/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+quarkus.application.name=non-application endpoints
+quarkus.http.root-path=/api
+quarkus.http.non-application-root-path=/q
+quarkus.http.redirect-to-non-application-root-path=true
+
+quarkus.swagger-ui.always-include=true
+quarkus.health.openapi.included=true

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/BackwardCompatibilityIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/BackwardCompatibilityIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class BackwardCompatibilityIT extends BackwardCompatibilityTest {
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/BackwardCompatibilityTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/BackwardCompatibilityTest.java
@@ -1,0 +1,47 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.in;
+
+import java.util.Collections;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qe.http.non_application.endpoint.HelloResource;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class BackwardCompatibilityTest extends CommonNonAppEndpoint {
+    private static final String BASE_PATH = "/q";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest backwardScenario = new QuarkusProdModeTest()
+            .overrideConfigKey("quarkus.http.root-path", "/api")
+            .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
+            .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "true")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(HelloResource.class));
+
+    @BeforeEach
+    public void beforeEach() {
+        backwardScenario.stop();
+        backwardScenario.start();
+    }
+
+    @Test
+    @DisplayName("Non-application relative path")
+    public void nonAppEndpointsWithRootPathAndNonAppRootPath() {
+        for (String endpoint : nonAppEndpoints) {
+            given().redirects().follow(false)
+                    .log().uri()
+                    .expect().statusCode(301).header("Location", endsWith("/q" + endpoint)).when().get(endpoint);
+
+            given().expect().statusCode(in(Collections.singletonList(200))).when().get(endpoint);
+        }
+    }
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/CommonNonAppEndpoint.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/CommonNonAppEndpoint.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+
+public abstract class CommonNonAppEndpoint {
+    protected static final String ROOT_BASE_PATH = "/api/";
+    private RequestSpecification request;
+    private RequestSpecBuilder spec;
+
+    protected final List<String> nonAppEndpoints = Arrays.asList(
+            "/openapi", "/metrics/base", "/metrics/application",
+            "/metrics/vendor", "/metrics", "/health/group", "/health/well", "/health/ready",
+            "/health/live", "/health");
+
+    protected void givenBasePath(String basePath) {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+        this.spec = new RequestSpecBuilder();
+        this.spec.setBasePath(basePath);
+    }
+
+    protected void whenMakeRequestOverNonAppEndpoints() {
+        this.request = spec.build();
+    }
+
+    protected void thenStatusCodeShouldBe(int status) {
+        for (String endpoint : nonAppEndpoints) {
+            given().spec(request).log().uri().expect().statusCode(status).when().get(endpoint);
+        }
+    }
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NonAppEndpointIT extends NonAppEndpointTest {
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NonAppEndpointNonRootPathIT extends NonAppEndpointNonRootPathTest {
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qe.http.non_application.endpoint.HelloResource;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class NonAppEndpointNonRootPathTest extends CommonNonAppEndpoint {
+    private static final String BASE_PATH = "/";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest nonRootPathScenario = new QuarkusProdModeTest()
+            .overrideConfigKey("quarkus.http.root-path", "/api")
+            .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
+            .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(HelloResource.class));
+
+    @BeforeEach
+    public void beforeEach() {
+        nonRootPathScenario.stop();
+        nonRootPathScenario.start();
+    }
+
+    @Test
+    @DisplayName("Non-application endpoint with root-path set to 'api' and non-application-root-path set to '/'")
+    public void nonAppEndpointsRootPathSlash() {
+        givenBasePath(ROOT_BASE_PATH);
+        whenMakeRequestOverNonAppEndpoints();
+        thenStatusCodeShouldBe(404);
+    }
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qe.http.non_application.endpoint.HelloResource;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class NonAppEndpointTest extends CommonNonAppEndpoint {
+    private static final String BASE_PATH = "/q";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest nonApplicationEndpointScenario = new QuarkusProdModeTest()
+            .overrideConfigKey("quarkus.http.root-path", "/api")
+            .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
+            .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(HelloResource.class));
+
+    @BeforeEach
+    public void beforeEach() {
+        nonApplicationEndpointScenario.stop();
+        nonApplicationEndpointScenario.start();
+    }
+
+    @Test
+    @DisplayName("Non-application endpoint with root-path set to 'api' and non-application-root-path set to q")
+    public void nonAppEndpointsWithRootPathAndNonAppRootPath() {
+        givenBasePath(BASE_PATH);
+        whenMakeRequestOverNonAppEndpoints();
+        thenStatusCodeShouldBe(200);
+    }
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NonAppEndpointTestNonBaseRootPathIT extends NonAppEndpointTestNonBaseRootPathTest {
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qe.http.non_application.endpoint.HelloResource;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class NonAppEndpointTestNonBaseRootPathTest extends CommonNonAppEndpoint {
+    private static final String BASE_PATH = "/q";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest emptyRootPathScenario = new QuarkusProdModeTest()
+            .overrideConfigKey("quarkus.http.root-path", "/")
+            .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
+            .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(HelloResource.class));
+
+    @BeforeEach
+    public void beforeEach() {
+        emptyRootPathScenario.stop();
+        emptyRootPathScenario.start();
+    }
+
+    @Test
+    @DisplayName("Non-application endpoint with quarkus.http.root-path set to '/'")
+    public void nonAppEndpointsBasePathSlash() {
+        givenBasePath(BASE_PATH);
+        whenMakeRequestOverNonAppEndpoints();
+        thenStatusCodeShouldBe(200);
+    }
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class RelativePathNonAppEndpointIT extends RelativePathNonAppEndpointTest {
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointTest.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.qe.http.non_application.endpoint.HelloResource;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class RelativePathNonAppEndpointTest extends CommonNonAppEndpoint {
+    private static final String BASE_PATH = "q";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest relativePathScenario = new QuarkusProdModeTest()
+            .overrideConfigKey("quarkus.http.root-path", "/api")
+            .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
+            .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(HelloResource.class));
+
+    @BeforeEach
+    public void beforeEach() {
+        relativePathScenario.stop();
+        relativePathScenario.start();
+    }
+
+    @Test
+    @DisplayName("Non-application relative path")
+    public void nonAppEndpointsWithRootPathAndNonAppRootPath() {
+        givenBasePath(ROOT_BASE_PATH + BASE_PATH);
+        whenMakeRequestOverNonAppEndpoints();
+        thenStatusCodeShouldBe(200);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
       <module>017-quartz-cluster</module>
       <module>018-quarkus-runtime-properties</module>
       <module>019-quarkus-consul</module>
+      <module>020-quarkus-http-non-application-endpoints</module>
       <module>101-javaee-like-getting-started</module>
       <module>201-large-static-content</module>
       <module>300-quarkus-vertx-webClient</module>


### PR DESCRIPTION
This PR cover non-application endpoint behavior:

* Relative paths: 

```
# Application.properties example
quarkus.http.root-path=/api
quarkus.http.non-application-root-path=q
quarkus.http.redirect-to-non-application-root-path=false
```

Valid request example: `http://localhost:8080/api/q/health`

* Empty non-application root path:

```
# Application.properties example
quarkus.http.root-path=/api
quarkus.http.non-application-root-path=/
quarkus.http.redirect-to-non-application-root-path=false
```
All request will return an HTTP status `404`

* Non-application root path with `slash` base path:
```
# Application.properties example
%emptyRootPath.quarkus.http.root-path=/
%emptyRootPath.quarkus.http.non-application-root-path=/q
%emptyRootPath.quarkus.http.redirect-to-non-application-root-path=false
```

Valid request example: `http://localhost:8080/q/health`

* Defined application base path and non-application root path:

```
# Application.properties example
quarkus.http.root-path=/api
quarkus.http.non-application-root-path=/q
quarkus.http.redirect-to-non-application-root-path=false
```

Valid request example: `http://localhost:8080/q/health`

* Backward compatibility (allow redirections):

```
quarkus.http.root-path=/api
quarkus.http.non-application-root-path=/q
quarkus.http.redirect-to-non-application-root-path=true
```

Valid request example: `http://localhost:8080/api/health`, will be redirected to `http://localhost:8080/q/health`

**Note:** If you want to run this branch on your local environment you will need to download and compile the following [branch](https://github.com/kenfinnigan/quarkus/tree/non-app-endpoints)
