### PR TITLE
JPA mapping values coverage

### DIFF
--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/BookRepository.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/BookRepository.java
@@ -1,29 +1,31 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.qe.spring.data.model.Book;
 import java.util.List;
+
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-public interface BookRepository extends Repository<Book, Integer> {
+import io.quarkus.qe.spring.data.model.Book;
 
-    // issue 9192
+public interface BookRepository extends CrudRepository<Book, Integer> {
+
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/9192
     @Query(value = "SELECT b.publicationYear FROM Book b where b.bid = :bid")
     int customFindPublicationYearPrimitive(@Param("bid") Integer bid);
 
-    // issue 9192
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/9192
     @Query(value = "SELECT b.publicationYear FROM Book b where b.bid = :bid")
     Integer customFindPublicationYearObject(@Param("bid") Integer bid);
 
-    // issue 9192
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/9192
     @Query(value = "SELECT b.isbn FROM Book b where b.bid = :bid")
     long customFindPublicationIsbnPrimitive(@Param("bid") Integer bid);
 
-    // issue 9192
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/9192
     @Query(value = "SELECT b.isbn FROM Book b where b.bid = :bid")
     Long customFindPublicationIsbnObject(@Param("bid") Integer bid);
 
-    // issue QUARKUS-525
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/13015
     List<Book> findByPublisherAddressZipCode(@Param("zipCode") String zipCode);
 }

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/BookResource.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/BookResource.java
@@ -1,11 +1,15 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.qe.spring.data.model.Book;
 import java.util.List;
+
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+
+import io.quarkus.qe.spring.data.model.Book;
 
 @Path("/book")
 public class BookResource {
@@ -14,6 +18,15 @@ public class BookResource {
 
     public BookResource(BookRepository bookRepository) {
         this.bookRepository = bookRepository;
+    }
+
+    @PUT
+    @Produces("application/json")
+    @Path("/{id}")
+    public Book updateBook(@PathParam("id") Integer id, final Book book) {
+        verifyBookExists(id);
+        book.setBid(id);
+        return bookRepository.save(book);
     }
 
     @GET
@@ -47,8 +60,13 @@ public class BookResource {
     @GET
     @Path("/publisher/zipcode/{zipCode}")
     @Produces("application/json")
-    public List<Book> findBooksByPublicationYear(@PathParam("zipCode") String zipCode) {
+    public List<Book> findBooksByZipCode(@PathParam("zipCode") String zipCode) {
         return bookRepository.findByPublisherAddressZipCode(zipCode);
     }
 
+    private void verifyBookExists(Integer id) {
+        if (!bookRepository.existsById(id)) {
+            throw new NotFoundException(String.format("book with id=%d was not found", id));
+        }
+    }
 }

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/CatRepository.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/CatRepository.java
@@ -1,18 +1,20 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.qe.spring.data.model.Cat;
 import java.util.List;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
+import io.quarkus.qe.spring.data.model.Cat;
+
 public interface CatRepository extends CrudRepository<Cat, Long> {
 
-    // issue 9192
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/9192
     @Query(value = "SELECT c.distinctive FROM Cat c where c.id = :id")
     boolean customFindDistinctivePrimitive(@Param("id") Long id);
 
-    // issue 9192
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/9192
     @Query(value = "SELECT c.distinctive FROM Cat c where c.id = :id")
     Boolean customFindDistinctiveObject(@Param("id") Long id);
 

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/CatResource.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/CatResource.java
@@ -1,11 +1,13 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.qe.spring.data.model.Cat;
 import java.util.List;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+
+import io.quarkus.qe.spring.data.model.Cat;
 
 @Path("/cat")
 public class CatResource {

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/HttpCommonsHeaders.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/HttpCommonsHeaders.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.qe.spring.data.configuration.InstanceIdBean;
-import io.quarkus.qe.spring.data.configuration.RequestIdBean;
-import io.quarkus.qe.spring.data.configuration.SessionIdBean;
+import static io.quarkus.qe.spring.data.configuration.AppConfiguration.getAndIncIndex;
+
+
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -10,7 +10,9 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
-import static io.quarkus.qe.spring.data.configuration.AppConfiguration.getAndIncIndex;
+import io.quarkus.qe.spring.data.configuration.InstanceIdBean;
+import io.quarkus.qe.spring.data.configuration.RequestIdBean;
+import io.quarkus.qe.spring.data.configuration.SessionIdBean;
 
 @Provider
 public class HttpCommonsHeaders implements ContainerResponseFilter {

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Address.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Address.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe.spring.data.model;
 
 import java.util.List;
+
 import javax.json.bind.annotation.JsonbTransient;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Animal.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Animal.java
@@ -1,12 +1,13 @@
 package io.quarkus.qe.spring.data.model;
 
 import java.time.LocalDateTime;
+
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
-// issue QUARKUS-525
+//This is for regression test for https://github.com/quarkusio/quarkus/pull/13015
 @MappedSuperclass
 public class Animal {
 

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Book.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Book.java
@@ -1,5 +1,9 @@
 package io.quarkus.qe.spring.data.model;
 
+import java.util.Map;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -14,9 +18,13 @@ public class Book extends NamedEntity {
 
     private Long isbn;
 
-    @ManyToOne(targetEntity=Address.class)
+    @ManyToOne(targetEntity = Address.class)
     @JoinColumn(name = "addressId")
     private Address publisherAddress;
+
+    @Column(name = "comments")
+    @Convert(converter = MapStringConverter.class)
+    private Map<String, String> comments;
 
     public Book() {
     }
@@ -57,5 +65,13 @@ public class Book extends NamedEntity {
 
     public void setPublisherAddress(Address publisherAddress) {
         this.publisherAddress = publisherAddress;
+    }
+
+    public Map<String, String> getComments() {
+        return comments;
+    }
+
+    public void setComments(Map<String, String> comments) {
+        this.comments = comments;
     }
 }

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Mammal.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/Mammal.java
@@ -2,7 +2,7 @@ package io.quarkus.qe.spring.data.model;
 
 import javax.persistence.MappedSuperclass;
 
-// issue QUARKUS-525
+//This is for regression test for https://github.com/quarkusio/quarkus/pull/13015
 @MappedSuperclass
 public class Mammal extends Animal {
 

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/MapStringConverter.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/MapStringConverter.java
@@ -1,0 +1,38 @@
+package io.quarkus.qe.spring.data.model;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.persistence.AttributeConverter;
+
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class MapStringConverter implements AttributeConverter<Map<String, String>, String> {
+    private static final String EMPTY = "{}";
+    private final Logger logger = Logger.getLogger(MapStringConverter.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, String> attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (IOException e) {
+            logger.error("Error while converting Map to JSON String: ", e);
+            return "";
+        }
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(Optional.ofNullable(dbData).orElse(EMPTY), Map.class);
+        } catch (Exception e) {
+            logger.error("Error while converting JSON String to Map: ", e);
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/NamedEntity.java
+++ b/601-spring-data-primitive-types/src/main/java/io/quarkus/qe/spring/data/model/NamedEntity.java
@@ -22,4 +22,3 @@ public class NamedEntity {
         this.name = name;
     }
 }
-

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/BookResourceTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/BookResourceTest.java
@@ -1,18 +1,24 @@
 package io.quarkus.qe.spring.data;
 
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.qe.spring.data.model.Book;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import java.util.Arrays;
-import java.util.List;
-import org.junit.jupiter.api.Test;
-
-import static io.restassured.RestAssured.when;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.Matchers.empty;
 
 @QuarkusTest
 public class BookResourceTest {
@@ -45,14 +51,45 @@ public class BookResourceTest {
                 .body(is("9789295055026"));
     }
 
-    // QUARKUS-525
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/13015
     @Test
     void testFindBooksByPublisherZipCode() {
+        List<Book> books = retrieveBooksByZipcode();
+        books.stream().forEach(book -> assertThat(book.getPublisherAddress().getZipCode(), is("28080")));
+    }
+
+    //This is for regression test for https://github.com/quarkusio/quarkus/issues/13234
+    @Test
+    void testJpaFieldsMapping() {
+        Book book = retrieveBooksByZipcode().stream().findFirst().get();
+
+        // Post a new comment on an existing book
+        Map<String, String> comment = Collections.singletonMap("Shakespeare", "Lorem Ipsum Lorem Ipsum");
+        book.setComments(comment);
+        book = updateBook(book);
+
+        assertThat(book.getComments().size(), equalTo(1));
+        assertThat(book.getComments(), equalTo(comment));
+
+        // Update the previous comment
+        Map<String, String> commentUpdated = Collections.singletonMap("Shakespeare", "Lorem Ipsum Lorem Ipsum novus");
+        book.setComments(commentUpdated);
+        book = updateBook(book);
+        assertThat(book.getComments().size(), equalTo(1));
+        assertThat(book.getComments(), equalTo(commentUpdated));
+    }
+
+    private Book updateBook(Book book) {
+        return given().contentType(ContentType.JSON).body(book).when().put("/book/" + book.getBid()).then()
+                .statusCode(200).contentType(ContentType.JSON).extract().response().getBody().as(Book.class);
+    }
+
+    private List<Book> retrieveBooksByZipcode() {
         Response response = when().get("/book/publisher/zipcode/28080").then()
                 .statusCode(200).contentType(ContentType.JSON).extract().response();
 
         List<Book> books = Arrays.asList(response.getBody().as(Book[].class));
         assertThat(books, is(not(empty())));
-        books.stream().forEach(book -> assertThat(book.getPublisherAddress().getZipCode(), is("28080")));
+        return books;
     }
 }

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CatResourceTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CatResourceTest.java
@@ -1,16 +1,19 @@
 package io.quarkus.qe.spring.data;
 
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
 import io.quarkus.qe.spring.data.model.Cat;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import java.util.Arrays;
-import java.util.List;
-import org.junit.jupiter.api.Test;
-
-import static io.restassured.RestAssured.when;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 
 @QuarkusTest
 public class CatResourceTest {
@@ -20,13 +23,15 @@ public class CatResourceTest {
                 .statusCode(200)
                 .body(is("true"));
     }
+
     @Test
     void testCustomFindPublicationYearPrimitiveBoolean() {
         when().get("/cat/customFindDistinctivePrimitive/2").then()
                 .statusCode(200)
                 .body(is("true"));
     }
-    // QUARKUS-532
+
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/13015
     @Test
     void testFindCatsByDeathReason() {
         Response response = when().get("/cat/findCatsByMappedSuperclassField/covid19").then()

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersTest.java
@@ -1,15 +1,5 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
-import io.restassured.http.Headers;
-import io.restassured.response.Response;
-import java.util.HashSet;
-import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -17,49 +7,65 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
+
 @QuarkusTest
 public class CommonsHeadersTest {
-    // QUARKUS-547
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/12234
     @Test
     @DisplayName("prototype scope: x-count header must be equal to request amount")
-    void testRequestAmount(){
+    void testRequestAmount() {
         Set<String> xCount = new HashSet<>();
 
-        for(int index = 0; index < 3; index++){
-            Headers headers =  when().get("/cat/customFindDistinctivePrimitive/2").headers();
+        for (int index = 0; index < 3; index++) {
+            Headers headers = when().get("/cat/customFindDistinctivePrimitive/2").headers();
             xCount.addAll(headers.getValues("x-count"));
         }
 
-        assertThat("Unexpected x-count header value(Spring Prototype Scope). Must be the same as HTTP request amount.", xCount.size(), is(3));
+        assertThat("Unexpected x-count header value(Spring Prototype Scope). Must be the same as HTTP request amount.",
+                xCount.size(), is(3));
     }
-    // QUARKUS-547
+
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/12234
     @Test
     @DisplayName("Singleton scope: x-instance-id header must be the same")
-    void testInstanceId(){
+    void testInstanceId() {
         Set<String> instanceIds = new HashSet<>();
-        for(int index = 0; index < 3; index++){
-            Headers headers =  when().get("/cat/customFindDistinctivePrimitive/2").headers();
+        for (int index = 0; index < 3; index++) {
+            Headers headers = when().get("/cat/customFindDistinctivePrimitive/2").headers();
             instanceIds.addAll(headers.getValues("x-instance"));
         }
 
         assertThat("Unexpected x-instance header value(Spring Singleton Scope). Must be 1", instanceIds.size(), is(1));
     }
-    // QUARKUS-547
+
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/12234
     @Test
     @DisplayName("request scope: x-request header must be equal to request amount")
     public void testRequestScope() {
         Set<String> requestIds = new HashSet<>();
-        for(int index = 0; index < 3; index++){
-            Headers headers =  when().get("/cat/customFindDistinctivePrimitive/2").headers();
+        for (int index = 0; index < 3; index++) {
+            Headers headers = when().get("/cat/customFindDistinctivePrimitive/2").headers();
             requestIds.addAll(headers.getValues("x-request"));
         }
 
-        assertThat("Unexpected x-request header value(Spring Request Scope). Must be the same as HTTP request amount.", requestIds.size(), is(3));
+        assertThat("Unexpected x-request header value(Spring Request Scope). Must be the same as HTTP request amount.",
+                requestIds.size(), is(3));
     }
-    // QUARKUS-547
+
+    //This is for regression test for https://github.com/quarkusio/quarkus/pull/12234
     @Test
     @DisplayName("session scope")
-    public void testSessionScope(){
+    public void testSessionScope() {
         final Response first = when().get("/cat/customFindDistinctivePrimitive/2");
         final String sessionId = first.sessionId();
         Headers headers = RestAssured.given()
@@ -82,11 +88,13 @@ public class CommonsHeadersTest {
                 .put("/session/invalidate")
                 .then();
 
-        Response second  = RestAssured.given()
+        Response second = RestAssured.given()
                 .sessionId(sessionId)
                 .get("/cat/customFindDistinctivePrimitive/2");
 
-        assertNotEquals( first.header("x-session"), second.header("x-session"), "First http session can't be the same as second http session");
-        assertNotEquals( sessionId, second.sessionId(), "(Spring Session scope) Two request from different sessions must have different x-session header.");
+        assertNotEquals(first.header("x-session"), second.header("x-session"),
+                "First http session can't be the same as second http session");
+        assertNotEquals(sessionId, second.sessionId(),
+                "(Spring Session scope) Two request from different sessions must have different x-session header.");
     }
 }


### PR DESCRIPTION
The aim of this PR is to cover JPA `convert` annotation, motivated by this [issue](https://github.com/quarkusio/quarkus/issues/13234)

We have created a new field over the `Book` entity called `comments`. The type of this field is a `mutable type (a Map)`, and is converted to a JSON String through a JPA `convert` annotation. 

