### PR TITLE
Disable 002 module in Native

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -62,8 +62,7 @@ jobs:
         run: |
           mvn -V -B -s .github/mvn-settings.xml -fae clean verify -Dnative \
             -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g \
-            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }} \
-            -pl '!002-quarkus-all-extensions'
+            -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
       - name: Zip Artifacts
         run: |
           zip -R artifacts-native${{ matrix.java }}.zip '*-reports/*'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         }
         stage('Test Native') {
             steps {
-                sh "GRAALVM_HOME=$JAVA_HOME ./mvnw -B -fae clean verify -Dnative -Dquarkus.native.native-image-xmx=6g -pl '!002-quarkus-all-extensions'"
+                sh "GRAALVM_HOME=$JAVA_HOME ./mvnw -B -fae clean verify -Dnative -Dquarkus.native.native-image-xmx=6g"
             }
             post {
                 always {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
 
   <modules>
       <module>001-quarkus-getting-started-with-jaxrs</module>
-      <module>002-quarkus-all-extensions</module>
       <module>003-quarkus-many-extensions</module>
       <module>004-quarkus-HHH-and-HV</module>
       <module>005-quarkus-and-maven-profiles</module>
@@ -144,6 +143,16 @@
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <id>high-memory-needed</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <!-- This module only works when running it in JVM mode -->
+        <module>002-quarkus-all-extensions</module>
+      </modules>
+    </profile>
     <profile>
       <id>native</id>
       <activation>


### PR DESCRIPTION
This PR is motivated because we can't exclude modules via Maven argument for the Quarkus ecosystem.