### PR TITLE
Remove workaround for Vert.x Params param underscore

### DIFF
--- a/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/BasicsRouteHandler.java
+++ b/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/BasicsRouteHandler.java
@@ -7,8 +7,13 @@ import io.vertx.core.http.HttpMethod;
 
 @RouteBase(path = "/basics")
 public class BasicsRouteHandler {
-    @Route(methods = HttpMethod.GET, path = "/param-with-hyphen/:first-param")
-    void validateRequestSingleParam(@Param("first-param") String param) {
+    @Route(methods = HttpMethod.GET, path = "/param-with-underscore/:first_param")
+    boolean validateRequestSingleParam(@Param("first_param") String param) {
+        return true;
+    }
+
+    @Route(methods = HttpMethod.GET, path = "/method-return-empty/:first_param")
+    void validateMethodWithEmptyResponse(@Param("first_param") String param) {
         // do nothing
     }
 }

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/BasicsRouteHandlerTest.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/BasicsRouteHandlerTest.java
@@ -12,11 +12,19 @@ import io.quarkus.test.junit.QuarkusTest;
 public class BasicsRouteHandlerTest {
 
     @Test
-    @Disabled("TODO: It returns HTTP 404 Not Found. Reported in https://github.com/quarkusio/quarkus/issues/15185")
-    public void shouldWorkUsingParamsWithHyphen() {
+    public void shouldWorkUsingParamsWithUnderscore() {
         given().when()
-                .get("/param-with-hyphen/work")
+                .get("/basics/param-with-underscore/work")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Disabled("TODO: Caused by https://github.com/quarkusio/quarkus/issues/15470")
+    @Test
+    public void shouldWorkCallingAMethodWithEmptyResponse() {
+        given().when()
+                .get("/basics/method-return-empty/work")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
     }
 }


### PR DESCRIPTION
It seems that hyphens are not legal, but we can change the method to use underscore. 
I've added another scenario for a new issue.