### PR TITLE
Avoid ports collision in 020-quarkus-http-non-application-endpoints for native mode

### DIFF
--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/BackwardCompatibilityIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/BackwardCompatibilityIT.java
@@ -1,7 +1,11 @@
 package io.quarkus.qe.non_application.endpoint;
 
-import io.quarkus.test.junit.NativeImageTest;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
-@NativeImageTest
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class BackwardCompatibilityIT extends BackwardCompatibilityTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/BackwardCompatibilityTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/BackwardCompatibilityTest.java
@@ -1,14 +1,16 @@
 package io.quarkus.qe.non_application.endpoint;
 
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.IS_NATIVE;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.nonAppEndpoints;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.in;
+
 
 import java.util.Collections;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -16,22 +18,18 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.qe.http.non_application.endpoint.HelloResource;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class BackwardCompatibilityTest extends CommonNonAppEndpoint {
+public class BackwardCompatibilityTest {
     private static final String BASE_PATH = "/q";
 
     @RegisterExtension
     static final QuarkusProdModeTest backwardScenario = new QuarkusProdModeTest()
+            .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/api")
             .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
             .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "true")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(HelloResource.class));
-
-    @BeforeEach
-    public void beforeEach() {
-        backwardScenario.stop();
-        backwardScenario.start();
-    }
+                    .addClass(HelloResource.class))
+            .setRun(true);
 
     @Test
     @DisplayName("Non-application relative path")

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/CommonNonAppEndpoint.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/CommonNonAppEndpoint.java
@@ -2,8 +2,11 @@ package io.quarkus.qe.non_application.endpoint;
 
 import static io.restassured.RestAssured.given;
 
+
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -11,10 +14,13 @@ import io.restassured.specification.RequestSpecification;
 
 public abstract class CommonNonAppEndpoint {
     protected static final String ROOT_BASE_PATH = "/api/";
+    protected static final String QUARKUS_PROFILE = "quarkus.profile";
+    protected static final String NATIVE = "native";
+    protected static final boolean IS_NATIVE = System.getProperty(QUARKUS_PROFILE, "").equals(NATIVE);
     private RequestSpecification request;
     private RequestSpecBuilder spec;
 
-    protected final List<String> nonAppEndpoints = Arrays.asList(
+    protected static final List<String> nonAppEndpoints = Arrays.asList(
             "/openapi", "/metrics/base", "/metrics/application",
             "/metrics/vendor", "/metrics", "/health/group", "/health/well", "/health/ready",
             "/health/live", "/health");
@@ -34,4 +40,15 @@ public abstract class CommonNonAppEndpoint {
             given().spec(request).log().uri().expect().statusCode(status).when().get(endpoint);
         }
     }
+
+    @Test
+    protected void nonAppEndpointScenario() {
+        givenBasePath(getBasePath());
+        whenMakeRequestOverNonAppEndpoints();
+        thenStatusCodeShouldBe(getExpectedHttpStatus());
+    }
+
+    public abstract int getExpectedHttpStatus();
+
+    public abstract String getBasePath();
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.non_application.endpoint;
 
-import io.quarkus.test.junit.NativeImageTest;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
-@NativeImageTest
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class NonAppEndpointIT extends NonAppEndpointTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathIT.java
@@ -1,7 +1,11 @@
 package io.quarkus.qe.non_application.endpoint;
 
-import io.quarkus.test.junit.NativeImageTest;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
-@NativeImageTest
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class NonAppEndpointNonRootPathIT extends NonAppEndpointNonRootPathTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathTest.java
@@ -1,10 +1,9 @@
 package io.quarkus.qe.non_application.endpoint;
 
+import javax.ws.rs.core.Response;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qe.http.non_application.endpoint.HelloResource;
@@ -15,23 +14,21 @@ public class NonAppEndpointNonRootPathTest extends CommonNonAppEndpoint {
 
     @RegisterExtension
     static final QuarkusProdModeTest nonRootPathScenario = new QuarkusProdModeTest()
+            .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/api")
             .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
             .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(HelloResource.class));
+                    .addClass(HelloResource.class))
+            .setRun(true);
 
-    @BeforeEach
-    public void beforeEach() {
-        nonRootPathScenario.stop();
-        nonRootPathScenario.start();
+    @Override
+    public int getExpectedHttpStatus() {
+        return Response.Status.NOT_FOUND.getStatusCode();
     }
 
-    @Test
-    @DisplayName("Non-application endpoint with root-path set to 'api' and non-application-root-path set to '/'")
-    public void nonAppEndpointsRootPathSlash() {
-        givenBasePath(ROOT_BASE_PATH);
-        whenMakeRequestOverNonAppEndpoints();
-        thenStatusCodeShouldBe(404);
+    @Override
+    public String getBasePath() {
+        return ROOT_BASE_PATH;
     }
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTest.java
@@ -1,37 +1,35 @@
 package io.quarkus.qe.non_application.endpoint;
 
+import javax.ws.rs.core.Response;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qe.http.non_application.endpoint.HelloResource;
 import io.quarkus.test.QuarkusProdModeTest;
 
 public class NonAppEndpointTest extends CommonNonAppEndpoint {
+
     private static final String BASE_PATH = "/q";
 
     @RegisterExtension
     static final QuarkusProdModeTest nonApplicationEndpointScenario = new QuarkusProdModeTest()
+            .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/api")
             .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
             .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(HelloResource.class));
+                    .addClass(HelloResource.class))
+            .setRun(true);
 
-    @BeforeEach
-    public void beforeEach() {
-        nonApplicationEndpointScenario.stop();
-        nonApplicationEndpointScenario.start();
+    @Override
+    public int getExpectedHttpStatus() {
+        return Response.Status.OK.getStatusCode();
     }
 
-    @Test
-    @DisplayName("Non-application endpoint with root-path set to 'api' and non-application-root-path set to q")
-    public void nonAppEndpointsWithRootPathAndNonAppRootPath() {
-        givenBasePath(BASE_PATH);
-        whenMakeRequestOverNonAppEndpoints();
-        thenStatusCodeShouldBe(200);
+    @Override
+    public String getBasePath() {
+        return BASE_PATH;
     }
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.non_application.endpoint;
 
-import io.quarkus.test.junit.NativeImageTest;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
-@NativeImageTest
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class NonAppEndpointTestNonBaseRootPathIT extends NonAppEndpointTestNonBaseRootPathTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathTest.java
@@ -1,37 +1,35 @@
 package io.quarkus.qe.non_application.endpoint;
 
+import javax.ws.rs.core.Response;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qe.http.non_application.endpoint.HelloResource;
 import io.quarkus.test.QuarkusProdModeTest;
 
 public class NonAppEndpointTestNonBaseRootPathTest extends CommonNonAppEndpoint {
+
     private static final String BASE_PATH = "/q";
 
     @RegisterExtension
     static final QuarkusProdModeTest emptyRootPathScenario = new QuarkusProdModeTest()
+            .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/")
             .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
             .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClasses(HelloResource.class));
+                    .addClasses(HelloResource.class))
+            .setRun(true);
 
-    @BeforeEach
-    public void beforeEach() {
-        emptyRootPathScenario.stop();
-        emptyRootPathScenario.start();
+    @Override
+    public int getExpectedHttpStatus() {
+        return Response.Status.OK.getStatusCode();
     }
 
-    @Test
-    @DisplayName("Non-application endpoint with quarkus.http.root-path set to '/'")
-    public void nonAppEndpointsBasePathSlash() {
-        givenBasePath(BASE_PATH);
-        whenMakeRequestOverNonAppEndpoints();
-        thenStatusCodeShouldBe(200);
+    @Override
+    public String getBasePath() {
+        return BASE_PATH;
     }
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.non_application.endpoint;
 
-import io.quarkus.test.junit.NativeImageTest;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
-@NativeImageTest
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class RelativePathNonAppEndpointIT extends RelativePathNonAppEndpointTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointTest.java
@@ -1,37 +1,35 @@
 package io.quarkus.qe.non_application.endpoint;
 
+import javax.ws.rs.core.Response;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qe.http.non_application.endpoint.HelloResource;
 import io.quarkus.test.QuarkusProdModeTest;
 
 public class RelativePathNonAppEndpointTest extends CommonNonAppEndpoint {
+
     private static final String BASE_PATH = "q";
 
     @RegisterExtension
     static final QuarkusProdModeTest relativePathScenario = new QuarkusProdModeTest()
+            .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/api")
             .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
             .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addClass(HelloResource.class));
+                    .addClass(HelloResource.class))
+            .setRun(true);
 
-    @BeforeEach
-    public void beforeEach() {
-        relativePathScenario.stop();
-        relativePathScenario.start();
+    @Override
+    public int getExpectedHttpStatus() {
+        return Response.Status.OK.getStatusCode();
     }
 
-    @Test
-    @DisplayName("Non-application relative path")
-    public void nonAppEndpointsWithRootPathAndNonAppRootPath() {
-        givenBasePath(ROOT_BASE_PATH + BASE_PATH);
-        whenMakeRequestOverNonAppEndpoints();
-        thenStatusCodeShouldBe(200);
+    @Override
+    public String getBasePath() {
+        return ROOT_BASE_PATH + BASE_PATH;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                     <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    <quarkus.profile>native</quarkus.profile>
                   </systemProperties>
                 </configuration>
               </execution>


### PR DESCRIPTION
When you are running your test, using `QuarkusProdModeTest` you should avoid using `@NativeImageTest` annotation, otherwise, you will have a collision between ports. because `@NativeImageTest` will launch an app over port 8081 and `QuarkusProdModeTest` will launch another app per test, over the same port. 

We have defined a 'quarkus.profile' system property on `maven-failsafe-plugin`. Based on this property, we will build a native image or a JVM instance. 