### PR TITLE
Configure mandrel image for daily builds

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -41,8 +41,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-#        image: [ "ubi-quarkus-native-image:21.0-java11", "ubi-quarkus-mandrel:21.0-java11" ]
-        image: [ "ubi-quarkus-native-image:21.0-java11" ] # till https://github.com/graalvm/mandrel/issues/218 gets resolved
+        image: [ "ubi-quarkus-native-image:21.0-java11", "ubi-quarkus-mandrel:21.0-java11" ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
After https://github.com/graalvm/mandrel/issues/218#issuecomment-792832701 has been fixed and new images have been populated, this PR is about to reenable the mandrel image.