### PR TITLE
[Master] Updated module 004 module to reproduce data loss issues

### DIFF
--- a/004-quarkus-HHH-and-HV/README.md
+++ b/004-quarkus-HHH-and-HV/README.md
@@ -1,3 +1,6 @@
 # Quarkus - Hibernate and Hibernate Validator (lazy fetch strategy)
 This scenario uses in-memory Java database H2.  
 Test class annotated with `@QuarkusTestResource(H2DatabaseTestResource.class)` starts an in-memory H2 database
+
+Module that covers integration with some Hibernate features like:
+- Reproducer for [14201](https://github.com/quarkusio/quarkus/issues/14201) and [14881](https://github.com/quarkusio/quarkus/issues/14881): possible data loss bug in hibernate. This is covered under the Java package `io.quarkus.qe.hibernate.items`.

--- a/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/Account.java
+++ b/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/Account.java
@@ -1,0 +1,37 @@
+package io.quarkus.qe.hibernate.items;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Entity
+public class Account {
+
+    @Id
+    public Long id;
+
+    @Column(length = 255, unique = true, nullable = false)
+    @NotNull
+    @Size(max = 255)
+    public String email;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    public Date createdOn;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "account_in_role", joinColumns = @JoinColumn(name = "accountid"), inverseJoinColumns = @JoinColumn(name = "roleid"))
+    public Set<Role> roles = new HashSet<>();
+
+}

--- a/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/Customer.java
+++ b/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/Customer.java
@@ -1,0 +1,32 @@
+package io.quarkus.qe.hibernate.items;
+
+import java.util.Date;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.Version;
+
+@Entity
+public class Customer {
+
+    @Id
+    public Long id;
+
+    @Version
+    @Column(name = "version")
+    public int version;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    public Date createdOn;
+
+    @OneToOne(optional = false, fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})
+    public Account account;
+
+
+}

--- a/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/Item.java
+++ b/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/Item.java
@@ -1,0 +1,21 @@
+package io.quarkus.qe.hibernate.items;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Item {
+
+    @Id
+    public Long id;
+
+    public String note;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customerId")
+    public Customer customer;
+
+}

--- a/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/ItemsResource.java
+++ b/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/ItemsResource.java
@@ -1,0 +1,33 @@
+package io.quarkus.qe.hibernate.items;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/items")
+@Transactional
+public class ItemsResource {
+
+    @Inject
+    EntityManager em;
+
+    @GET
+    @Path("/count")
+    public int countOrders() {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Item> cq = cb.createQuery(Item.class);
+        // Eager fetch the relationship between item and customer
+        // Do not remove as this is the actual reproducer for https://github.com/quarkusio/quarkus/issues/14201 and
+        // https://github.com/quarkusio/quarkus/issues/14881.
+        cq.from(Item.class).fetch("customer");
+
+        TypedQuery<Item> query = em.createQuery(cq);
+        return query.getResultList().size();
+    }
+
+}

--- a/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/Role.java
+++ b/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/items/Role.java
@@ -1,0 +1,16 @@
+package io.quarkus.qe.hibernate.items;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class Role {
+
+    @Id
+    public Long id;
+
+    @Column
+    public String name;
+
+}

--- a/004-quarkus-HHH-and-HV/src/main/resources/application.properties
+++ b/004-quarkus-HHH-and-HV/src/main/resources/application.properties
@@ -4,3 +4,4 @@ quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.datasource.jdbc.min-size=3
 quarkus.datasource.jdbc.max-size=10
 quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.sql-load-script=import.sql

--- a/004-quarkus-HHH-and-HV/src/main/resources/import.sql
+++ b/004-quarkus-HHH-and-HV/src/main/resources/import.sql
@@ -1,0 +1,5 @@
+insert into account (id, email) values (1, 'foo@bar.com');
+insert into role (id, name) values  (1, 'admin');
+insert into account_in_role (accountid, roleid) values (1, 1);
+insert into customer (id, version, account_id) values (1,  1, 1);
+insert into item (id, note, customerid) values (1, 'Item 1', 1);

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/items/ItemsResourceTest.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/items/ItemsResourceTest.java
@@ -1,0 +1,20 @@
+package io.quarkus.qe.hibernate.items;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ItemsResourceTest {
+
+    /**
+     * Required data is pulled in from the `import.sql` resource.
+     */
+    @Test
+    public void shouldNotFailWithConstraints() {
+        given().when().get("/items/count").then().body(is("1"));
+    }
+}

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/items/NativeItemsResourceIT.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/items/NativeItemsResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.hibernate.items;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeItemsResourceIT extends ItemsResourceTest {
+}


### PR DESCRIPTION
Added coverage for issues:
- https://github.com/quarkusio/quarkus/issues/14201
- https://github.com/quarkusio/quarkus/issues/14881

Note that this solution is based on the reproducer provided in one of the above issues: https://github.com/yntelectual/quarkus-bug-14201

I verified that the new test does not work if we run it with 1.11.1.Final (as an example):

```
mvn clean install -Dquarkus-plugin.version=1.11.1.Final -Dquarkus.platform.version=1.11.1.Final
``` 

As expected, It fails with:

```
Caused by: org.postgresql.util.PSQLException: ERROR: null value in column "email" of relation "account" violates not-null constraint
  Detail: Failing row contains (1, null, null).
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2553)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2285)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:323)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:473)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:393)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:164)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:130)
	at io.agroal.pool.wrapper.PreparedStatementWrapper.executeUpdate(PreparedStatementWrapper.java:86)
	at org.hibernate.engine.jdbc.internal.ResultSetReturnImpl.executeUpdate(ResultSetReturnImpl.java:197)
```

It works fine when running with 1.11.5.Final or 999-SNAPSHOT. Verified also in Native. 

This PR must be backported to 1.11 branch too.