### PR TITLE
Remove invalid Vert.x route to prevent app starts

### DIFF
--- a/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/BasicsRouteHandler.java
+++ b/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/BasicsRouteHandler.java
@@ -11,9 +11,4 @@ public class BasicsRouteHandler {
     boolean validateRequestSingleParam(@Param("first_param") String param) {
         return true;
     }
-
-    @Route(methods = HttpMethod.GET, path = "/method-return-empty/:first_param")
-    void validateMethodWithEmptyResponse(@Param("first_param") String param) {
-        // do nothing
-    }
 }

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/BasicsRouteHandlerTest.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/BasicsRouteHandlerTest.java
@@ -3,7 +3,6 @@ package io.quarkus.qe;
 import static io.restassured.RestAssured.given;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -17,14 +16,5 @@ public class BasicsRouteHandlerTest {
                 .get("/basics/param-with-underscore/work")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
-    }
-
-    @Disabled("TODO: Caused by https://github.com/quarkusio/quarkus/issues/15470")
-    @Test
-    public void shouldWorkCallingAMethodWithEmptyResponse() {
-        given().when()
-                .get("/basics/method-return-empty/work")
-                .then()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
     }
 }


### PR DESCRIPTION
The resolution from https://github.com/quarkusio/quarkus/issues/15470 was to avoid having routes that do not return anything. So, if the app spots a route of this kind, the app will crash because of validation error at startup. Hence, we need to remove this route now.