### PR TITLE
Add timeouts for Module 013

### DIFF
--- a/013-quarkus-oidc-restclient/src/main/resources/application.properties
+++ b/013-quarkus-oidc-restclient/src/main/resources/application.properties
@@ -24,8 +24,9 @@ io.quarkus.qe.ping.clients.ReactivePongClient/mp-rest/scope=javax.inject.Singlet
 io.quarkus.qe.ping.clients.LookupAuthorizationPongClient/mp-rest/url=http://localhost:8081
 io.quarkus.qe.ping.clients.LookupAuthorizationPongClient/mp-rest/scope=javax.inject.Singleton
 
+io.quarkus.qe.ping.clients.AutoAcquireTokenPongClient/mp-rest/url=http://localhost:8081
+
+io.quarkus.qe.ping.clients.TokenPropagationPongClient/mp-rest/url=http://localhost:8081
+
 #OpenAPI
 quarkus.smallrye-openapi.store-schema-directory=target/generated/jax-rs/
-
-io.quarkus.qe.ping.clients.AutoAcquireTokenPongClient/mp-rest/url=http://localhost:8081
-io.quarkus.qe.ping.clients.TokenPropagationPongClient/mp-rest/url=http://localhost:8081

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
@@ -1,19 +1,23 @@
 package io.quarkus.qe;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.config.HttpClientConfig.httpClientConfig;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 
-
-import io.quarkus.qe.model.Score;
-import io.restassured.http.ContentType;
 import java.util.UUID;
+
 import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.authorization.client.AuthzClient;
 
 import io.quarkus.qe.containers.KeycloakTestResource;
+import io.quarkus.qe.model.Score;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.restassured.RestAssured;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.http.ContentType;
 
 @QuarkusTestResource(KeycloakTestResource.class)
 public abstract class AbstractPingPongResourceTest {
@@ -23,7 +27,19 @@ public abstract class AbstractPingPongResourceTest {
     private static final String USER = "test-user";
     private static final String WRONG_TOKEN = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
+    private static final String HTTP_SOCKET_TIMEOUT_PROPERTY = "http.socket.timeout";
+    private static final String HTTP_CONNECTION_TIMEOUT_PROPERTY = "http.connection.timeout";
+    private static final int TIMEOUT_IN_SECONDS = 1000;
+
     AuthzClient authzClient;
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.config = RestAssuredConfig.config()
+                .httpClient(httpClientConfig()
+                        .setParam(HTTP_SOCKET_TIMEOUT_PROPERTY, TIMEOUT_IN_SECONDS)
+                        .setParam(HTTP_CONNECTION_TIMEOUT_PROPERTY, TIMEOUT_IN_SECONDS));
+    }
 
     @Test
     public void testPingUnauthorized() {


### PR DESCRIPTION
Adding timeout using Rest Assured for the Module 013. This is motivated because it failed in Jenkins when verifying Quarkus 1.11.5:

```
15:09:08 [INFO] -------------< io.quarkus.qe:013-quarkus-oidc-restclient >--------------
15:09:08 [INFO] Building 013-quarkus-oidc-restclient 1.0.0-SNAPSHOT              [14/27]
15:09:08 [INFO] --------------------------------[ jar ]---------------------------------
15:09:08 [INFO] 
15:09:08 [INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ 013-quarkus-oidc-restclient ---
15:09:08 [INFO] 
15:09:08 [INFO] --- quarkus-maven-plugin:1.11.5.Final-redhat-00006:generate-code (default) @ 013-quarkus-oidc-restclient ---
15:09:08 [INFO] Downloading from libs-snapshot-local: http://10.0.139.54:8040/artifactory/libs-snapshot-local/io/quarkus/qe/013-quarkus-oidc-restclient/1.0.0-SNAPSHOT/maven-metadata.xml
15:09:10 [INFO] 
// ...
15:09:11 [INFO] 
15:09:11 [INFO] --- maven-surefire-plugin:2.22.1:test (default-test) @ 013-quarkus-oidc-restclient ---
15:09:11 [INFO] 
15:09:11 [INFO] -------------------------------------------------------
15:09:11 [INFO]  T E S T S
15:09:11 [INFO] -------------------------------------------------------
15:09:12 [INFO] Running io.quarkus.qe.TokenPropagationPingPongResourceTest
15:09:12 [WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.004 s - in io.quarkus.qe.TokenPropagationPingPongResourceTest
15:09:12 [INFO] Running io.quarkus.qe.ReactivePingPongResourceTest
16:00:42 Build timed out (after 60 minutes). Marking the build as aborted.
16:00:42 Build was aborted
16:00:42 Recording test results
```

Note that it remained up to 50 min in ReactivePingPongResourceTest. I suspect that this is hanging when calling to the rest client because I added a sleep in the rest client body and it never stopped. 

Adding the timeout at rest assured level should be safer.
