### PR TITLE
[master] Enable tests to cover validation for Panache and Spring REST

### DIFF
--- a/011-quarkus-panache-rest-flyway/src/test/java/io/quarkus/qe/PostgreSqlApplicationResourceTest.java
+++ b/011-quarkus-panache-rest-flyway/src/test/java/io/quarkus/qe/PostgreSqlApplicationResourceTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -71,9 +72,8 @@ public class PostgreSqlApplicationResourceTest {
     public void shouldReturnBadRequestIfApplicationNameIsNull() {
         applicationPath().body(new ApplicationEntity()).post()
                 .then()
-                .statusCode(HttpStatus.SC_BAD_REQUEST);
-                // TODO: Body assertion is not working caused by https://github.com/quarkusio/quarkus/issues/15492
-                // .body(containsString("name can't be null"));
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(containsString("name can't be null"));
     }
 
     @Test

--- a/602-spring-data-rest/src/test/java/org/acme/spring/data/rest/BookRepositoryTest.java
+++ b/602-spring-data-rest/src/test/java/org/acme/spring/data/rest/BookRepositoryTest.java
@@ -118,11 +118,7 @@ class BookRepositoryTest {
                 .body("{\"name\": \"Q\", \"author\": \"Li\"}")
                 .when().post("/books")
                 .then()
-                .statusCode(HttpStatus.SC_BAD_REQUEST);
-                // TODO: Body assertion is not working caused by https://github.com/quarkusio/quarkus/issues/15492
-                // .body(
-                //        containsString("length must be between 2 and 50"),
-                //        containsString("propertyPath=name")
-                //);
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(containsString("length must be between 2 and 50"));
     }
 }

--- a/602-spring-data-rest/src/test/java/org/acme/spring/data/rest/LibraryRepositoryTest.java
+++ b/602-spring-data-rest/src/test/java/org/acme/spring/data/rest/LibraryRepositoryTest.java
@@ -1,14 +1,15 @@
 package org.acme.spring.data.rest;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
 import org.acme.spring.data.rest.containers.PostgreSqlDatabaseTestResource;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(PostgreSqlDatabaseTestResource.class)
@@ -80,10 +81,7 @@ public class LibraryRepositoryTest {
                 .body("{\"name\": \"\"}")
                 .when().post("/library")
                 .then()
-                .statusCode(HttpStatus.SC_BAD_REQUEST);
-                // TODO: Body assertion is not working caused by https://github.com/quarkusio/quarkus/issues/15492
-                //.body(
-                //        containsString("Name may not be blank")
-                //);
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(containsString("Name may not be blank"));
     }
 }


### PR DESCRIPTION
The issue https://github.com/quarkusio/quarkus/issues/15492#event-4450469504 has been resolved, so we need to enable back the coverage to cover this functionality.