### PR TITLE
Added reproducer for QUARKUS-661

### DIFF
--- a/004-quarkus-HHH-and-HV/README.md
+++ b/004-quarkus-HHH-and-HV/README.md
@@ -4,3 +4,4 @@ Test class annotated with `@QuarkusTestResource(H2DatabaseTestResource.class)` s
 
 Module that covers integration with some Hibernate features like:
 - Reproducer for [14201](https://github.com/quarkusio/quarkus/issues/14201) and [14881](https://github.com/quarkusio/quarkus/issues/14881): possible data loss bug in hibernate. This is covered under the Java package `io.quarkus.qe.hibernate.items`.
+- Reproducer for [QUARKUS-661](https://issues.redhat.com/browse/QUARKUS-661): @TransactionScoped Context does not call @Predestroy on TransactionScoped Beans. This is covered under the Java package `io.quarkus.qe.hibernate.transaction`.

--- a/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/transaction/TransactionScopeBean.java
+++ b/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/transaction/TransactionScopeBean.java
@@ -1,0 +1,34 @@
+package io.quarkus.qe.hibernate.transaction;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.transaction.TransactionScoped;
+
+@TransactionScoped
+public class TransactionScopeBean {
+    public static final AtomicBoolean PRE_DESTROY_INVOKED = new AtomicBoolean(false);
+    public static final AtomicBoolean POST_CONSTRUCT_INVOKED = new AtomicBoolean(false);
+
+    private int value = 0;
+
+    public int increment() {
+        return ++value;
+    }
+
+    @PostConstruct
+    void postConstruct() {
+        POST_CONSTRUCT_INVOKED.set(true);
+    }
+
+    @PreDestroy
+    void preDestroy() {
+        PRE_DESTROY_INVOKED.set(true);
+    }
+
+    public static void resetFlags() {
+        PRE_DESTROY_INVOKED.set(false);
+        POST_CONSTRUCT_INVOKED.set(false);
+    }
+}

--- a/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/transaction/TransactionScopeBeanResource.java
+++ b/004-quarkus-HHH-and-HV/src/main/java/io/quarkus/qe/hibernate/transaction/TransactionScopeBeanResource.java
@@ -1,0 +1,35 @@
+package io.quarkus.qe.hibernate.transaction;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+@Path("/transaction-scope")
+public class TransactionScopeBeanResource {
+
+    @Inject
+    TransactionScopeBean bean;
+
+    @POST
+    @Transactional
+    @Path("/invoke-bean")
+    public int invokeBean() {
+        TransactionScopeBean.resetFlags();
+        return bean.increment();
+    }
+
+    @GET
+    @Path("/is-post-construct-invoked")
+    public boolean isPostConstructInvoked() {
+        return TransactionScopeBean.POST_CONSTRUCT_INVOKED.get();
+    }
+
+    @GET
+    @Path("/is-pre-destroy-invoked")
+    public boolean isPreDestroyInvoked() {
+        return TransactionScopeBean.PRE_DESTROY_INVOKED.get();
+    }
+
+}

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/transaction/NativeTransactionScopeBeanResourceIT.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/transaction/NativeTransactionScopeBeanResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe.hibernate.transaction;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeTransactionScopeBeanResourceIT extends TransactionScopeBeanResourceTest {
+
+}

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/transaction/TransactionScopeBeanResourceTest.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/transaction/TransactionScopeBeanResourceTest.java
@@ -1,0 +1,56 @@
+package io.quarkus.qe.hibernate.transaction;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class TransactionScopeBeanResourceTest {
+
+    private static final String TRANSACTION_SCOPE_BASE_PATH = "/transaction-scope";
+
+    private static final String EXPECTED_RESPONSE_FROM_INVOKE_BEAN = "1";
+    private static final String TRUE = Boolean.TRUE.toString();
+    private static final String FALSE = Boolean.FALSE.toString();
+
+    @Test
+    public void shouldPostConstructAndPreDestroyBeInvoked() {
+        givenPostConstructAndPreDestroyAreNotInvoked();
+        whenInvokeBean();
+        thenIsPostConstructInvoked();
+        thenIsPreDestroyInvoked();
+    }
+
+    private void givenPostConstructAndPreDestroyAreNotInvoked() {
+        assertEquals(FALSE, getPostConstructInvokeResult(), "PostConstruct method has been invoked already");
+        assertEquals(FALSE, getPreDestroyInvokeResult(), "PreDestroy method has been invoked already");
+    }
+
+    private void whenInvokeBean() {
+        given().when().post(transactionScopePath("/invoke-bean")).then().body(is(EXPECTED_RESPONSE_FROM_INVOKE_BEAN));
+    }
+
+    private void thenIsPostConstructInvoked() {
+        assertEquals(TRUE, getPostConstructInvokeResult(), "PostConstruct method is not invoked");
+    }
+
+    private void thenIsPreDestroyInvoked() {
+        assertEquals(TRUE, getPreDestroyInvokeResult(), "PreDestroy method is not invoked");
+    }
+
+    private String getPostConstructInvokeResult() {
+        return given().when().get(transactionScopePath("/is-post-construct-invoked")).asString();
+    }
+
+    private String getPreDestroyInvokeResult() {
+        return given().when().get(transactionScopePath("/is-pre-destroy-invoked")).asString();
+    }
+
+    private String transactionScopePath(String path) {
+        return TRANSACTION_SCOPE_BASE_PATH + path;
+    }
+}


### PR DESCRIPTION
Reproducer for https://issues.redhat.com/browse/QUARKUS-661. This was fixed in 1.11 as part of this PR: https://github.com/quarkusio/quarkus/pull/14053, but there was missing coverage for Native tests which was the motivation for this PR. 

When running the module 004 using:
```
mvn clean verify -Dtest=TransactionScopeBeanResourceTest
```

As expected, it will fail with:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 7.936 s <<< FAILURE! - in io.quarkus.qe.hibernate.transaction.TransactionScopeBeanResourceTest
[ERROR] shouldPostConstructAndPreDestroyBeInvoked  Time elapsed: 1.6 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: PostConstruct method is not invoked ==> expected: <true> but was: <false>
	at io.quarkus.qe.hibernate.transaction.TransactionScopeBeanResourceTest.thenIsPostConstructInvoked(TransactionScopeBeanResourceTest.java:38)
	at io.quarkus.qe.hibernate.transaction.TransactionScopeBeanResourceTest.shouldPostConstructAndPreDestroyBeInvoked(TransactionScopeBeanResourceTest.java:24)
```

Using upstream 1.11.6.Final or product release, it works.
Verified also in Native.