### PR TITLE
Revert "Spring Web + Smallrye OpenAPI coverage - failing cases"

### DIFF
--- a/603-spring-web-smallrye-openapi/src/test/resources/request-types.csv
+++ b/603-spring-web-smallrye-openapi/src/test/resources/request-types.csv
@@ -1,18 +1,13 @@
-##
-## Lines starting with '#' are ignored.
-## All ignored lines fail due to https://github.com/quarkusio/quarkus/issues/15443.
-## TODO: Uncomment after resolution.
-##
 /delete-text-plain,delete,text/plain
 /delete/no-type,delete,application/json
-#/delete/text-plain,delete,text/plain
+/delete/text-plain,delete,text/plain
 /delete/json,delete,application/json
-#/delete/octet-stream,delete,application/octet-stream
+/delete/octet-stream,delete,application/octet-stream
 /patch-text-plain,patch,text/plain
 /patch/no-type,patch,application/json
-#/patch/text-plain,patch,text/plain
+/patch/text-plain,patch,text/plain
 /patch/json,patch,application/json
-#/patch/octet-stream,patch,application/octet-stream
+/patch/octet-stream,patch,application/octet-stream
 /post-text-plain,post,text/plain
 /post/no-type,post,application/json
 /post/text-plain,post,text/plain
@@ -20,6 +15,6 @@
 /post/octet-stream,post,application/octet-stream
 /put-text-plain,put,text/plain
 /put/no-type,put,application/json
-#/put/text-plain,put,text/plain
+/put/text-plain,put,text/plain
 /put/json,put,application/json
-#/put/octet-stream,put,application/octet-stream
+/put/octet-stream,put,application/octet-stream

--- a/603-spring-web-smallrye-openapi/src/test/resources/response-types.csv
+++ b/603-spring-web-smallrye-openapi/src/test/resources/response-types.csv
@@ -1,23 +1,18 @@
-##
-## Lines starting with '#' are ignored.
-## All ignored lines fail due to https://github.com/quarkusio/quarkus/issues/15443.
-## TODO: Uncomment after resolution.
-##
 /delete-text-plain,delete,text/plain
 /delete/no-type,delete,application/json
-#/delete/text-plain,delete,text/plain
+/delete/text-plain,delete,text/plain
 /delete/json,delete,application/json
-#/delete/octet-stream,delete,application/octet-stream
+/delete/octet-stream,delete,application/octet-stream
 /get-text-plain,get,text/plain
 /get/no-type,get,application/json
-#/get/text-plain,get,text/plain
+/get/text-plain,get,text/plain
 /get/json,get,application/json
-#/get/octet-stream,get,application/octet-stream
+/get/octet-stream,get,application/octet-stream
 /patch-text-plain,patch,text/plain
 /patch/no-type,patch,application/json
-#/patch/text-plain,patch,text/plain
+/patch/text-plain,patch,text/plain
 /patch/json,patch,application/json
-#/patch/octet-stream,patch,application/octet-stream
+/patch/octet-stream,patch,application/octet-stream
 /post-text-plain,post,text/plain
 /post/no-type,post,application/json
 /post/text-plain,post,text/plain
@@ -25,6 +20,6 @@
 /post/octet-stream,post,application/octet-stream
 /put-text-plain,put,text/plain
 /put/no-type,put,application/json
-#/put/text-plain,put,text/plain
+/put/text-plain,put,text/plain
 /put/json,put,application/json
-#/put/octet-stream,put,application/octet-stream
+/put/octet-stream,put,application/octet-stream


### PR DESCRIPTION
Revert "Spring Web + Smallrye OpenAPI coverage - failing cases commented out".

Related to https://github.com/quarkus-qe/beefy-scenarios/pull/120.

This reverts commit 8c299b1447bab2dbf9a690f4b25af25609f89ad9.