### PR TITLE
Fix grpc port collision on test

### DIFF
--- a/009-quarkus-infinispan-grpc-kafka/src/main/resources/application.properties
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/resources/application.properties
@@ -11,6 +11,7 @@ quarkus.infinispan-client.sasl-mechanism=DIGEST-MD5
 
 # gRPC
 quarkus.grpc.clients.hello.host=localhost
+%test.quarkus.grpc.clients.hello.port=9001
 
 # Kafka
 # Configure the SmallRye Kafka connector


### PR DESCRIPTION
When we are running some test in Upstream, there is a port collision with GRPC .
Pickup [suggested changes](https://github.com/quarkusio/quarkus/issues/15934) 