### PR TITLE
Avoid mutiny/blocking grpc be under the same service in order to avoid service.name collisions.

### DIFF
--- a/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/greeting/BlockingHelloService.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/greeting/BlockingHelloService.java
@@ -1,14 +1,15 @@
 package io.quarkus.qe.greeting;
 
+import io.grpc.stub.StreamObserver;
+import io.quarkus.example.blocking.GreeterGrpc;
+import io.quarkus.example.dto.HelloReply;
+import io.quarkus.example.dto.HelloRequest;
 import javax.inject.Singleton;
 
-import io.grpc.stub.StreamObserver;
-import io.quarkus.example.GreeterGrpc;
-import io.quarkus.example.HelloReply;
-import io.quarkus.example.HelloRequest;
+
 
 @Singleton
-public class HelloService extends GreeterGrpc.GreeterImplBase {
+public class BlockingHelloService extends GreeterGrpc.GreeterImplBase{
 
     @Override
     public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {

--- a/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/greeting/GreetingResource.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/greeting/GreetingResource.java
@@ -1,5 +1,9 @@
 package io.quarkus.qe.greeting;
 
+import io.quarkus.example.blocking.GreeterGrpc;
+import io.quarkus.example.dto.HelloReply;
+import io.quarkus.example.dto.HelloRequest;
+import io.quarkus.example.mutiny.MutinyGreeterGrpc;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -7,10 +11,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import io.quarkus.example.GreeterGrpc;
-import io.quarkus.example.HelloReply;
-import io.quarkus.example.HelloRequest;
-import io.quarkus.example.MutinyGreeterGrpc;
 import io.quarkus.grpc.runtime.annotations.GrpcService;
 import io.smallrye.mutiny.Uni;
 
@@ -35,6 +35,6 @@ public class GreetingResource {
     @GET
     @Path("/mutiny/{name}")
     public Uni<String> hello(@PathParam("name") String name) {
-        return mutinyClient.sayHello(HelloRequest.newBuilder().setName(name).build()).map(HelloReply::getMessage);
+        return mutinyClient.sayHello(HelloRequest.newBuilder().setName(name).build()).onItem().transform(HelloReply::getMessage);
     }
 }

--- a/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/greeting/MutinyHelloService.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/greeting/MutinyHelloService.java
@@ -1,10 +1,11 @@
 package io.quarkus.qe.greeting;
 
+import io.quarkus.example.dto.HelloReply;
+import io.quarkus.example.dto.HelloRequest;
+import io.quarkus.example.mutiny.MutinyGreeterGrpc;
 import javax.inject.Singleton;
 
-import io.quarkus.example.HelloReply;
-import io.quarkus.example.HelloRequest;
-import io.quarkus.example.MutinyGreeterGrpc;
+
 import io.smallrye.mutiny.Uni;
 
 @Singleton

--- a/009-quarkus-infinispan-grpc-kafka/src/main/proto/dto.proto
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/proto/dto.proto
@@ -1,16 +1,10 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "io.quarkus.example";
-option java_outer_classname = "HelloWorldProto";
+option java_package = "io.quarkus.example.dto";
+option java_outer_classname = "dtos";
 
-package helloworld;
-
-// The greeting service definition.
-service Greeter {
-    // Sends a greeting
-    rpc SayHello (HelloRequest) returns (HelloReply) {}
-}
+package dto;
 
 // The request message containing the user's name.
 message HelloRequest {

--- a/009-quarkus-infinispan-grpc-kafka/src/main/proto/helloworld_blocking.proto
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/proto/helloworld_blocking.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.example.blocking";
+option java_outer_classname = "BlockingHelloWorldProto";
+
+package helloworld_blocking;
+
+import "dto.proto";
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (dto.HelloRequest) returns (dto.HelloReply) {}
+}

--- a/009-quarkus-infinispan-grpc-kafka/src/main/proto/helloworld_mutiny.proto
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/proto/helloworld_mutiny.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.quarkus.example.mutiny";
+option java_outer_classname = "MutinyHelloWorldProto";
+
+package helloworld_mutiny;
+
+import "dto.proto";
+
+// The greeting service definition.
+service Greeter {
+    // Sends a greeting
+    rpc SayHello (dto.HelloRequest) returns (dto.HelloReply) {}
+}


### PR DESCRIPTION
Refactor .proto files in order to avoid service names colissions:

Error example:
```
java.lang.IllegalStateException: Duplicated gRPC service: helloworld.Greeter
```