### PR TITLE
Add test to cover Quarkus configuration properties

### DIFF
--- a/022-quarkus-properties-config-all/.env
+++ b/022-quarkus-properties-config-all/.env
@@ -1,0 +1,1 @@
+WELCOME_MESSAGE=Welcome message from .env file

--- a/022-quarkus-properties-config-all/README.md
+++ b/022-quarkus-properties-config-all/README.md
@@ -1,0 +1,28 @@
+# Quarkus - Cover application properties setup
+This module tests different ways of configuring properties for Quarkus application
+
+1. Configuring custom user properties through nested static class (done for Antagonist)  
+1.1 Configuration properties located in the *application.properties* file
+
+2. Configuring custom user properties through set of interfaces (done for Protagonist)  
+2.1 Configuration properties located in the *application.yaml* file (this file takes precedence over the
+*application.properties* file)
+
+3. Configuring custom config source provider  
+3.1 File org.eclipse.microprofile.config.spi.ConfigSourceProvider must be created under **META-INF/services/**
+    and contains fully qualified names of implementations  
+3.2 Source provider in this example has ordinal(priority) value of 999, which means it should take precedence over the
+value located in .env file.
+
+4. Configuring custom converter  
+4.1 File org.eclipse.microprofile.config.spi.Converter must be created under **META-INF/services/**
+and contains fully qualified names of implementations  
+4.2 To create the custom converter POJO class must be created if you're not overriding any of the
+supported classes (e.x. String, Boolean, Double, etc.)
+
+
+___
+#### Wiki:
+**Protagonist**: the leading character in the story, whose purpose is to move story to its final  
+**Antagonist**: the adversary of the leading character (or protagonist) in the story, whose purpose is to
+interfere with the protagonist

--- a/022-quarkus-properties-config-all/pom.xml
+++ b/022-quarkus-properties-config-all/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.qe</groupId>
+        <artifactId>beefy-scenarios</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>022-quarkus-properties-config-all</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+                <quarkus.native.additional-build-args>-H:ResourceConfigurationFiles=resources-config.json</quarkus.native.additional-build-args>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/GreetingResource.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/GreetingResource.java
@@ -1,0 +1,76 @@
+package quarkus.qe;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import quarkus.qe.config.AntagonistConfiguration;
+import quarkus.qe.config.ProtagonistConfiguration;
+import quarkus.qe.converter.KrustyEmail;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @Inject
+    Config config;
+
+    @Inject
+    ProtagonistConfiguration protagonist;
+
+    @Inject
+    AntagonistConfiguration antagonist;
+
+    @ConfigProperty(name = "restaurant.employees")
+    List<KrustyEmail> employeesEmails;
+
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String welcomeMessage(){
+        return config.getValue("welcome.message", String.class);
+    } // declared in .env
+
+    @GET
+    @Path("/protagonist")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String helloProtagonist() {
+        return protagonist.getName() + " says: " + protagonist.getMessage() + ". My hobie is: " + protagonist.getHobby();
+    }
+
+    @GET
+    @Path("/protagonist/friend")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String helloProtagonistFriend() {
+        return protagonist.getFriendName() + " says: " + protagonist.getFriendMessage();
+    }
+
+    @GET
+    @Path("/antagonist")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String helloAntagonist() {
+        return antagonist.name + " says: " + antagonist.message;
+    }
+
+    @GET
+    @Path("/antagonist/wife")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String helloAntagonistWife() {
+        return antagonist.wife.name + " says: " + antagonist.wife.message;
+    }
+
+    @GET
+    @Path("/emails")
+    @Produces(MediaType.TEXT_PLAIN)
+    public List<String> printEmails() {
+        return employeesEmails.stream()
+                .map(employee -> employee.getEmail())
+                .collect(Collectors.toList());
+    }
+}

--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/config/AntagonistConfiguration.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/config/AntagonistConfiguration.java
@@ -1,0 +1,15 @@
+package quarkus.qe.config;
+
+import io.quarkus.arc.config.ConfigProperties;
+
+@ConfigProperties(prefix = "antagonist")
+public class AntagonistConfiguration {
+    public String message;
+    public String name;
+    public AntagonistWifeConfig wife;
+
+    public static class AntagonistWifeConfig {
+        public String name;
+        public String message;
+    }
+}

--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/config/ProtagonistConfiguration.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/config/ProtagonistConfiguration.java
@@ -1,0 +1,29 @@
+package quarkus.qe.config;
+
+import quarkus.qe.config.interfaces.ProtagonistConfigurable;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class ProtagonistConfiguration {
+
+    @Inject
+    ProtagonistConfigurable protagonistConfigurable;
+
+    public String getName(){
+        return protagonistConfigurable.name();
+    }
+
+    public String getMessage(){
+        return protagonistConfigurable.message();
+    }
+
+    public String getHobby() { return protagonistConfigurable.hobby(); }
+
+    public String getFriendName(){ return protagonistConfigurable.friend().name(); }
+
+    public String getFriendMessage(){
+        return protagonistConfigurable.friend().message();
+    }
+}

--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/config/interfaces/IBiography.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/config/interfaces/IBiography.java
@@ -1,0 +1,9 @@
+package quarkus.qe.config.interfaces;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+public interface IBiography {
+
+    @ConfigProperty(name = "hobby")
+    String hobby();
+}

--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/config/interfaces/ProtagonistConfigurable.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/config/interfaces/ProtagonistConfigurable.java
@@ -1,0 +1,24 @@
+package quarkus.qe.config.interfaces;
+
+import io.quarkus.arc.config.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ConfigProperties(prefix = "protagonist")
+public interface ProtagonistConfigurable extends IBiography {
+
+    @ConfigProperty(name = "name")
+    String name();
+
+    @ConfigProperty(name = "message")
+    String message();
+
+    Friend friend();
+
+    interface Friend {
+        @ConfigProperty(name = "name")
+        String name();
+
+        @ConfigProperty(name = "message")
+        String message();
+    }
+}

--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/converter/CustomEmailConverter.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/converter/CustomEmailConverter.java
@@ -1,0 +1,12 @@
+package quarkus.qe.converter;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+public class CustomEmailConverter implements Converter<KrustyEmail> {
+
+    @Override
+    public KrustyEmail convert(String str) {
+        String email = str.replaceAll("\\s","").toLowerCase()+"@krustykrab.com";
+        return new KrustyEmail(email);
+    }
+}

--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/converter/KrustyEmail.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/converter/KrustyEmail.java
@@ -1,0 +1,14 @@
+package quarkus.qe.converter;
+
+public class KrustyEmail {
+
+    private String email;
+
+    public KrustyEmail(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/providers/CustomConfigSource.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/providers/CustomConfigSource.java
@@ -1,0 +1,57 @@
+package quarkus.qe.providers;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+public class CustomConfigSource implements ConfigSource {
+
+    private static final int ORDINAL = 999;
+    private static final String PROPERTIES_FILE = "/configsource.properties";
+
+    Properties customProperties = new Properties();
+
+    @Override
+    public Map<String, String> getProperties() {
+        loadProperties();
+        Map<String, String> result = new HashMap<>();
+        for (Map.Entry<Object, Object> entry : customProperties.entrySet()) {
+            result.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+        }
+        return result;
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ORDINAL;
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        loadProperties();
+        return customProperties.getProperty(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return "Custom Config Source";
+    }
+
+    public void loadProperties(){
+        try {
+            InputStream in = CustomConfigSource.class.getResourceAsStream(PROPERTIES_FILE);
+            if (in != null) {
+                customProperties.load(in);
+            } else {
+                throw new FileNotFoundException("Property file " + PROPERTIES_FILE + " not found in the classpath");
+            }
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/022-quarkus-properties-config-all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/022-quarkus-properties-config-all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+quarkus.qe.providers.CustomConfigSource

--- a/022-quarkus-properties-config-all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/022-quarkus-properties-config-all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -1,0 +1,1 @@
+quarkus.qe.converter.CustomEmailConverter

--- a/022-quarkus-properties-config-all/src/main/resources/application.properties
+++ b/022-quarkus-properties-config-all/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+antagonist.name=Sheldon Plankton
+antagonist.message=Hi, I am Sheldon Plankton
+antagonist.wife.name=Karen
+antagonist.wife.message=Hi, I am Karen
+
+restaurant.employees=WillBeOverridden,WillBeOverridden,WillBeOverridden

--- a/022-quarkus-properties-config-all/src/main/resources/application.yaml
+++ b/022-quarkus-properties-config-all/src/main/resources/application.yaml
@@ -1,0 +1,12 @@
+protagonist:
+  name: Sponge Bob
+  message: Hi, I am Sponge Bob
+  hobby: WillBeOverriden
+  friend:
+    name: Patrick Star
+    message: Hi, I am Patrick Star
+restaurant:
+  employees:
+    - Sponge Bob
+    - Squidward Tentacles
+    - Eugene Krabs

--- a/022-quarkus-properties-config-all/src/main/resources/configsource.properties
+++ b/022-quarkus-properties-config-all/src/main/resources/configsource.properties
@@ -1,0 +1,1 @@
+protagonist.hobby=Jellyfishing

--- a/022-quarkus-properties-config-all/src/main/resources/resources-config.json
+++ b/022-quarkus-properties-config-all/src/main/resources/resources-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {
+      "pattern": "configsource.properties"
+    }
+  ]
+}

--- a/022-quarkus-properties-config-all/src/test/java/quarkus/qe/config/VariousConfigurationSourcesTest.java
+++ b/022-quarkus-properties-config-all/src/test/java/quarkus/qe/config/VariousConfigurationSourcesTest.java
@@ -1,0 +1,71 @@
+package quarkus.qe.config;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class VariousConfigurationSourcesTest {
+
+    @Test
+    public void testEnvFile() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("Welcome message from .env file"));
+    }
+
+    @Test
+    public void testYamlPropertiesByInterface() {
+        // Property 'protagonist.hobby' overridden by ./configsource.properties file that has higher ordinal(priority)
+        given()
+                .when().get("/hello/protagonist")
+                .then()
+                .statusCode(200)
+                .body(is("Sponge Bob says: Hi, I am Sponge Bob. My hobie is: Jellyfishing"));
+    }
+
+    @Test
+    public void testYamlPropertiesByInterfaceNested() {
+        given()
+                .when().get("/hello/protagonist/friend")
+                .then()
+                .statusCode(200)
+                .body(is("Patrick Star says: Hi, I am Patrick Star"));
+    }
+
+    @Test
+    public void testApplicationPropertiesByClass() {
+        given()
+                .when().get("/hello/antagonist")
+                .then()
+                .statusCode(200)
+                .body(is("Sheldon Plankton says: Hi, I am Sheldon Plankton"));
+    }
+
+    @Test
+    public void testApplicationPropertiesByClassNested() {
+        given()
+                .when().get("/hello/antagonist/wife")
+                .then()
+                .statusCode(200)
+                .body(is("Karen says: Hi, I am Karen"));
+    }
+
+    @Test
+    public void testCustomEmailConverter() {
+        // File ./application.yaml takes precedence over ./application.properties
+        given()
+                .when().get("/hello/emails")
+                .then()
+                .statusCode(200)
+                .body(
+                        containsString("spongebob@krustykrab.com"),
+                        containsString("squidwardtentacles@krustykrab.com"),
+                        containsString("eugenekrabs@krustykrab.com"));
+    }
+}

--- a/022-quarkus-properties-config-all/src/test/java/quarkus/qe/config/VariousConfigurationSourcesTestIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/quarkus/qe/config/VariousConfigurationSourcesTestIT.java
@@ -1,0 +1,9 @@
+package quarkus.qe.config;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class VariousConfigurationSourcesTestIT extends VariousConfigurationSourcesTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
       <module>019-quarkus-consul</module>
       <module>020-quarkus-http-non-application-endpoints</module>
       <module>021-quarkus-panache-multiple-pus</module>
+      <module>022-quarkus-properties-config-all</module>
       <module>101-javaee-like-getting-started</module>
       <module>201-large-static-content</module>
       <module>300-quarkus-vertx-webClient</module>


### PR DESCRIPTION
This test covers most of the config properties for Quarkus described in Configuring you Quarkus application guide
https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/1.7/html-single/configuring_your_quarkus_applications/index


resources-config.json file should be there according to https://quarkus.io/guides/writing-native-applications-tips#supporting-native-in-your-application (without it, the errors are thrown on the following line
`InputStream in = CustomConfigSource.class.getResourceAsStream(PROPERTIES_FILE);`
)

Module has reach README file

