### PR TITLE
Scenario for QUARKUS-858:Avoid message loss during the graceful shutdown

### DIFF
--- a/009-quarkus-infinispan-grpc-kafka/README.md
+++ b/009-quarkus-infinispan-grpc-kafka/README.md
@@ -1,6 +1,7 @@
 # Table of Contents
 1. [Quarkus infinispan grpc kafka](#Quarkus-infinispan-grpc-kafka)
 2. [Quarkus SSL/TLS Infinispan scenario ](#Quarkus-SSL/TLS-Infinispan-scenario )
+3. [Quarkus Grateful Shutdown for Kafka connectors](#Quarkus-Grateful-Shutdown-for-Kafka-connectors)
 
 ## Quarkus SSL/TLS infinispan grpc kafka
 Module that test whether gRPC, Infinispan and Kafka extensions work together:
@@ -18,3 +19,7 @@ Infinispan Server mimicked by Testcontainers.
 Test SSL/TLS secure connection between Infinispan client and Infinispan server.  
 Client and server are using the same `server.jks` file for authentication (client truststore / server keystore)  
 Information about Infinispan server configuration can be found at [this Github page](https://github.com/infinispan/infinispan-images)
+
+## Quarkus Grateful Shutdown for Kafka connectors
+This scenario covers the fix for [QUARKUS-858](https://issues.redhat.com/browse/QUARKUS-858): Avoid message loss during the graceful shutdown (SIGTERM) of the Kafka connector.
+The test will confirm that no messages are lost when the `grateful-shutdown` is enabled. In the other hand, when this property is disabled, messages might be lost.

--- a/009-quarkus-infinispan-grpc-kafka/pom.xml
+++ b/009-quarkus-infinispan-grpc-kafka/pom.xml
@@ -38,6 +38,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-infinispan-client</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/grateful/shutdown/SlowTopicConsumer.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/grateful/shutdown/SlowTopicConsumer.java
@@ -1,0 +1,26 @@
+package io.quarkus.qe.grateful.shutdown;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class SlowTopicConsumer {
+
+    private static final Logger LOG = Logger.getLogger(SlowTopicConsumer.class);
+
+    public static final int LOOP_TIMEOUT = 100;
+
+    @Incoming("slow")
+    @Acknowledgment(Acknowledgment.Strategy.MANUAL)
+    public CompletionStage<Void> process(Message<String> message) throws InterruptedException {
+        Thread.sleep(LOOP_TIMEOUT);
+        LOG.info("Processed " + message.getPayload());
+        return message.ack();
+    }
+}

--- a/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/grateful/shutdown/SlowTopicResource.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/grateful/shutdown/SlowTopicResource.java
@@ -1,0 +1,25 @@
+package io.quarkus.qe.grateful.shutdown;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+
+@Path("/slow-topic")
+public class SlowTopicResource {
+
+    @Inject
+    @Channel("slow-topic")
+    Emitter<String> emitter;
+
+    @POST
+    @Path("/sendMessages/{count}")
+    public void sendMessage(@PathParam("count") Integer count) {
+        for (int index = 1; index <= count; index++) {
+            emitter.send("Message " + index);
+        }
+    }
+}

--- a/009-quarkus-infinispan-grpc-kafka/src/main/resources/application.properties
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/resources/application.properties
@@ -20,6 +20,13 @@ mp.messaging.outgoing.generated-price.connector=smallrye-kafka
 mp.messaging.outgoing.generated-price.topic=prices
 mp.messaging.outgoing.generated-price.value.serializer=org.apache.kafka.common.serialization.IntegerSerializer
 
+mp.messaging.outgoing.slow-topic.connector=smallrye-kafka
+mp.messaging.outgoing.slow-topic.topic=slow
+mp.messaging.outgoing.slow-topic.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
 # Configure the Kafka source (we read from it)
 mp.messaging.incoming.prices.connector=smallrye-kafka
 mp.messaging.incoming.prices.value.deserializer=org.apache.kafka.common.serialization.IntegerDeserializer
+
+mp.messaging.incoming.slow.connector=smallrye-kafka
+mp.messaging.incoming.slow.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer

--- a/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/grateful/shutdown/KafkaGratefulShutdownTest.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/grateful/shutdown/KafkaGratefulShutdownTest.java
@@ -1,0 +1,118 @@
+package io.quarkus.qe.grateful.shutdown;
+
+import static io.restassured.RestAssured.post;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import org.jboss.logmanager.Level;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.LogFile;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class KafkaGratefulShutdownTest {
+
+    private static final int TOTAL_MESSAGES = 10;
+    private static final String GRATEFUL_SHUTDOWN_PROPERTY = "mp.messaging.incoming.slow.graceful-shutdown";
+    private static final String KAFKA_LOG_PROPERTY = "quarkus.log.category.\"io.smallrye.reactive.messaging.kafka\".level";
+    private static final String LAST_MESSAGE_LOG = "Processed Message " + TOTAL_MESSAGES;
+    private static final String SHUTDOWN_KAFKA_LOG = "Shutting down - Waiting for message processing to complete";
+
+    @RegisterExtension
+    static QuarkusProdModeTest app = new QuarkusProdModeTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .addClasses(SlowTopicResource.class, SlowTopicConsumer.class))
+            .setRuntimeProperties(Collections.singletonMap("quarkus.http.port", "8083"))
+            .setLogFileName("out.log")
+            .overrideConfigKey(KAFKA_LOG_PROPERTY, Level.DEBUG.getName())
+            .setRun(true);
+
+    @LogFile
+    Path logfile;
+
+    @Test
+    public void shouldWaitForMessagesWhenGratefulShutdownIsEnabled() {
+        givenApplicationWithGratefulShutdownEnabled();
+        givenMessagesInTopic();
+        whenStopApplication();
+        thenAllMessagesAreProcessedOrKafkaIsShutdown();
+    }
+
+    @Test
+    public void shouldNotWaitForMessagesWhenGratefulShutdownIsDisabled() {
+        givenApplicationWithGratefulShutdownDisabled();
+        givenMessagesInTopic();
+        whenStopApplication();
+        thenAllMessagesAreNotProcessed();
+    }
+
+    private void givenApplicationWithGratefulShutdownEnabled() {
+        app.overrideConfigKey(GRATEFUL_SHUTDOWN_PROPERTY, Boolean.TRUE.toString());
+        restart();
+    }
+
+    private void givenApplicationWithGratefulShutdownDisabled() {
+        app.overrideConfigKey(GRATEFUL_SHUTDOWN_PROPERTY, Boolean.FALSE.toString());
+        restart();
+    }
+
+    private void givenMessagesInTopic() {
+        post("/slow-topic/sendMessages/" + TOTAL_MESSAGES);
+    }
+
+    private void whenStopApplication() {
+        app.stop();
+    }
+
+    private void thenAllMessagesAreProcessedOrKafkaIsShutdown() {
+        thenAssertLogs(line -> line.contains(LAST_MESSAGE_LOG) || line.contains(SHUTDOWN_KAFKA_LOG),
+                "Expected output was not found in logs");
+    }
+
+    private void thenAllMessagesAreNotProcessed() {
+        thenLogsDoNotContain(LAST_MESSAGE_LOG);
+        thenLogsDoNotContain(SHUTDOWN_KAFKA_LOG);
+    }
+
+    private void thenLogsDoNotContain(String expectedOutput) {
+        thenAssertLogs(line -> !line.contains(expectedOutput), "Unexpected output was found in logs");
+    }
+
+    private void thenAssertLogs(Predicate<String> assertion, String message) {
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<String> elements = Collections.emptyList();
+            try {
+                elements = Files.readAllLines(logfile);
+            } catch (IOException ignored) {
+
+            }
+
+            assertTrue(elements.stream().anyMatch(assertion), message + ":" + elements);
+        });
+    }
+
+    private void restart() {
+        app.stop();
+        app.start();
+        if (logfile != null) {
+            try {
+                Files.write(logfile, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
+            } catch (IOException e) {
+                // ignored
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a scenario to cover the difference of behaviour when setting the `graceful-shutdown` property for Kafka connectors. 

Note that I could not add a Native scenario because the inject of `LogFile` is not working in this scenario.