### PR TITLE
Kstream commit interval config

### DIFF
--- a/012-quarkus-kafka-streams/src/main/resources/application.properties
+++ b/012-quarkus-kafka-streams/src/main/resources/application.properties
@@ -25,3 +25,10 @@ login.denied.threshold=1
 
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
+
+# pass-through options
+kafka-streams.cache.max.bytes.buffering=10240
+kafka-streams.commit.interval.ms=500
+kafka-streams.metadata.max.age.ms=500
+kafka-streams.auto.offset.reset=earliest
+kafka-streams.metrics.recording.level=DEBUG

--- a/012-quarkus-kafka-streams/src/test/resources/application.properties
+++ b/012-quarkus-kafka-streams/src/test/resources/application.properties
@@ -26,3 +26,10 @@ login.denied.threshold=1
 
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
+
+# pass-through options
+kafka-streams.cache.max.bytes.buffering=10240
+kafka-streams.commit.interval.ms=500
+kafka-streams.metadata.max.age.ms=500
+kafka-streams.auto.offset.reset=earliest
+kafka-streams.metrics.recording.level=DEBUG


### PR DESCRIPTION
Currently, we are not setting any `kafka-streams.commit.interval.ms` so looks like by default this property is set to `30000 milliseconds`. 

The test is going to take less time to succeed if we reduce this commit interval. 