### PR TITLE
Update Beefy TS to Quarkus 2.x (Vertx 4 - 999-SNAPSHOT)

### DIFF
--- a/022-quarkus-properties-config-all/src/main/java/quarkus/qe/providers/CustomConfigSource.java
+++ b/022-quarkus-properties-config-all/src/main/java/quarkus/qe/providers/CustomConfigSource.java
@@ -2,9 +2,9 @@ package quarkus.qe.providers;
 
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -13,16 +13,15 @@ public class CustomConfigSource implements ConfigSource {
     private static final int ORDINAL = 999;
     private static final String PROPERTIES_FILE = "/configsource.properties";
 
-    Properties customProperties = new Properties();
+    private final Properties customProperties = new Properties();
+
+    public CustomConfigSource() {
+        loadProperties();
+    }
 
     @Override
-    public Map<String, String> getProperties() {
-        loadProperties();
-        Map<String, String> result = new HashMap<>();
-        for (Map.Entry<Object, Object> entry : customProperties.entrySet()) {
-            result.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
-        }
-        return result;
+    public Set<String> getPropertyNames() {
+        return customProperties.keySet().stream().map(Object::toString).collect(Collectors.toSet());
     }
 
     @Override
@@ -32,7 +31,6 @@ public class CustomConfigSource implements ConfigSource {
 
     @Override
     public String getValue(String propertyName) {
-        loadProperties();
         return customProperties.getProperty(propertyName);
     }
 

--- a/101-javaee-like-getting-started/src/main/java/io/quarkus/qe/core/CustomHealthCheckGroup.java
+++ b/101-javaee-like-getting-started/src/main/java/io/quarkus/qe/core/CustomHealthCheckGroup.java
@@ -4,14 +4,15 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
-import org.eclipse.microprofile.health.Readiness;
 
-@Readiness
+import io.smallrye.health.api.HealthGroup;
+
+@HealthGroup("customGroup")
 @ApplicationScoped
-public class GreetingHealthCheck implements HealthCheck {
+public class CustomHealthCheckGroup implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
-        return HealthCheckResponse.builder().name("greeting").up().build();
+        return HealthCheckResponse.builder().name("custom-group").up().build();
     }
 }

--- a/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/JavaEELikeHealthCheckTest.java
+++ b/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/JavaEELikeHealthCheckTest.java
@@ -1,10 +1,16 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.*;
+import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 public class JavaEELikeHealthCheckTest {
@@ -22,6 +28,21 @@ public class JavaEELikeHealthCheckTest {
                         "checks.status", not(hasItem("DOWN"))
                 );
     }
+
+    @Test
+    public void testHealthGroupEndpoint() {
+        // TODO: There is an inconsistency about the Health groups path. Reported by https://github.com/quarkusio/quarkus/issues/16389.
+        given()
+                .when().get("/health/group/customGroup")
+                .then()
+                .statusCode(200)
+                .body("status", is("UP"),
+                        "checks.name",
+                        containsInAnyOrder("custom-group"),
+                        "checks.status", hasSize(1),
+                        "checks.status", hasItem("UP"));
+    }
+
     @Test
     public void testReadinessEndpoint() {
         given()
@@ -29,8 +50,8 @@ public class JavaEELikeHealthCheckTest {
                 .then()
                 .statusCode(200)
                 .body("status", is("UP"),
-                        "checks.name", containsInAnyOrder("readiness", "Database connections health check"),
-                        "checks.status", hasSize(2),
+                        "checks.name", containsInAnyOrder("readiness", "greeting", "Database connections health check"),
+                        "checks.status", hasSize(3),
                         "checks.status", hasItem("UP")
                 );
     }

--- a/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/auth/AuthN.java
+++ b/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/auth/AuthN.java
@@ -1,5 +1,10 @@
 package io.quarkus.qe.vertx.web.auth;
 
+import java.util.Arrays;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
 import io.quarkus.qe.vertx.web.config.AuthNConfig;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
@@ -7,9 +12,6 @@ import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.mutiny.core.Vertx;
-import java.util.Arrays;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
 
 public class AuthN {
 
@@ -22,14 +24,16 @@ public class AuthN {
     @Produces
     JWTAuth jwtAuth() {
         return JWTAuth.create(vertx.getDelegate(), new JWTAuthOptions().setJWTOptions(getJwtOptions())
-                .addPubSecKey(new PubSecKeyOptions(authConfig())));
+                .addPubSecKey(getPubSecKeyOptions()));
     }
 
-    private JsonObject authConfig(){
-        return new JsonObject()
+    private PubSecKeyOptions getPubSecKeyOptions() {
+        JsonObject authConfig = new JsonObject()
                 .put("symmetric", true)
                 .put("algorithm", authNConf.alg)
                 .put("publicKey", authNConf.secret);
+
+        return new PubSecKeyOptions(authConfig).setBuffer(authConfig.getBuffer("publicKey"));
     }
 
     private JWTOptions getJwtOptions() {

--- a/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/handlers/JWTHandler.java
+++ b/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/handlers/JWTHandler.java
@@ -1,13 +1,14 @@
 package io.quarkus.qe.vertx.web.handlers;
 
-import io.quarkus.qe.vertx.web.config.AuthNConfig;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.web.RoutingContext;
-import java.time.ZonedDateTime;
-import java.util.Arrays;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 @ApplicationScoped
 public class JWTHandler {

--- a/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/services/AbstractRedisDao.java
+++ b/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/services/AbstractRedisDao.java
@@ -1,11 +1,5 @@
 package io.quarkus.qe.vertx.web.services;
 
-import io.quarkus.qe.vertx.web.exceptions.NotFoundException;
-import io.quarkus.qe.vertx.web.model.Record;
-import io.quarkus.redis.client.reactive.ReactiveRedisClient;
-import io.smallrye.mutiny.Multi;
-import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.redis.client.Response;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -13,7 +7,15 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import javax.inject.Inject;
+
+import io.quarkus.qe.vertx.web.exceptions.NotFoundException;
+import io.quarkus.qe.vertx.web.model.Record;
+import io.quarkus.redis.client.reactive.ReactiveRedisClient;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
 
 public abstract class AbstractRedisDao<E extends Record> {
 

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/jwt/JwtTest.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/jwt/JwtTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.jwt.JWK;
-import io.vertx.ext.jwt.JWT;
+import io.vertx.ext.auth.impl.jose.JWK;
+import io.vertx.ext.auth.impl.jose.JWT;
 
 public class JwtTest {
 

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/AirlineHandler.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/AirlineHandler.java
@@ -1,23 +1,23 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
-
-import io.quarkus.qe.vertx.sql.domain.Airline;
-
-import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.qe.vertx.sql.domain.Record;
-import io.quarkus.vertx.web.Route;
-import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.RoutingContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.qe.vertx.sql.domain.Airline;
+import io.quarkus.qe.vertx.sql.domain.Record;
+import io.quarkus.qe.vertx.sql.services.DbPoolService;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
+import io.quarkus.vertx.web.RouteBase;
+import io.vertx.ext.web.RoutingContext;
 
 @Tag(name = "Airlines", description = "Manage your airports")
 @Singleton

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/AirportsHandler.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/AirportsHandler.java
@@ -1,21 +1,23 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
-import io.quarkus.qe.vertx.sql.domain.Airport;
-import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.qe.vertx.sql.domain.Record;
-import io.quarkus.vertx.web.Route;
-import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.RoutingContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.qe.vertx.sql.domain.Airport;
+import io.quarkus.qe.vertx.sql.domain.Record;
+import io.quarkus.qe.vertx.sql.services.DbPoolService;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
+import io.quarkus.vertx.web.RouteBase;
+import io.vertx.ext.web.RoutingContext;
 
 @Tag(name = "Airports", description = "Manage your airports")
 @Singleton

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/BasketHandler.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/BasketHandler.java
@@ -16,10 +16,9 @@ import io.quarkus.qe.vertx.sql.domain.Record;
 import io.quarkus.qe.vertx.sql.services.DbPoolService;
 import io.quarkus.vertx.web.Body;
 import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
 import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.RoutingContext;
-
 
 @Tag(name = "Basket", description = "Manage your basket")
 @Singleton

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/FlightsHandler.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/FlightsHandler.java
@@ -1,21 +1,10 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
-import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.qe.vertx.sql.domain.Flight;
-import io.quarkus.qe.vertx.sql.domain.QueryFlightSearch;
-import io.quarkus.qe.vertx.sql.domain.Record;
-import io.quarkus.qe.vertx.sql.services.FlightSearchService;
-import io.quarkus.vertx.web.Body;
-import io.quarkus.vertx.web.Param;
-import io.quarkus.vertx.web.Route;
-import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.Json;
-import io.vertx.ext.web.RoutingContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.validation.Valid;
+
 import org.eclipse.microprofile.openapi.annotations.OpenAPIDefinition;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -26,6 +15,19 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.qe.vertx.sql.domain.Flight;
+import io.quarkus.qe.vertx.sql.domain.QueryFlightSearch;
+import io.quarkus.qe.vertx.sql.domain.Record;
+import io.quarkus.qe.vertx.sql.services.DbPoolService;
+import io.quarkus.qe.vertx.sql.services.FlightSearchService;
+import io.quarkus.vertx.web.Body;
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
+import io.quarkus.vertx.web.RouteBase;
+import io.vertx.core.json.Json;
+import io.vertx.ext.web.RoutingContext;
 
 @OpenAPIDefinition(
         info = @Info(

--- a/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/PricingRulesHandler.java
+++ b/303-quarkus-vertx-sql/src/main/java/io/quarkus/qe/vertx/sql/handlers/PricingRulesHandler.java
@@ -1,21 +1,23 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
-import io.quarkus.qe.vertx.sql.services.DbPoolService;
-import io.quarkus.qe.vertx.sql.domain.PricingRules;
-import io.quarkus.qe.vertx.sql.domain.Record;
-import io.quarkus.vertx.web.Route;
-import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.web.RoutingContext;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import io.quarkus.qe.vertx.sql.domain.PricingRules;
+import io.quarkus.qe.vertx.sql.domain.Record;
+import io.quarkus.qe.vertx.sql.services.DbPoolService;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
+import io.quarkus.vertx.web.RouteBase;
+import io.vertx.ext.web.RoutingContext;
 
 @Tag(name = "Pricing Rules", description = "Manage your business pricing rules")
 @Singleton

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/CommonTestCases.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/CommonTestCases.java
@@ -31,7 +31,8 @@ public abstract class CommonTestCases implements
     @Test
     public void basketScenario() {
         basketCheckout();
-        wrongBasketFormatCheckout();
+        // TODO: Validation stopped being propagated onto error handler. Reported by https://github.com/quarkusio/quarkus/issues/16430
+        // wrongBasketFormatCheckout();
     }
 
     @Test

--- a/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/BasicsRouteHandler.java
+++ b/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/BasicsRouteHandler.java
@@ -2,8 +2,8 @@ package io.quarkus.qe;
 
 import io.quarkus.vertx.web.Param;
 import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
 import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
 
 @RouteBase(path = "/basics")
 public class BasicsRouteHandler {

--- a/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/validation/ValidationOnRequestBodyRouteHandler.java
+++ b/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/validation/ValidationOnRequestBodyRouteHandler.java
@@ -4,8 +4,8 @@ import javax.validation.Valid;
 
 import io.quarkus.vertx.web.Body;
 import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
 import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
 
 @RouteBase(path = "/validate")
 public class ValidationOnRequestBodyRouteHandler {

--- a/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/validation/ValidationOnRequestParamsRouteHandler.java
+++ b/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/validation/ValidationOnRequestParamsRouteHandler.java
@@ -6,8 +6,8 @@ import javax.validation.constraints.Size;
 import io.quarkus.qe.validation.annotations.Uppercase;
 import io.quarkus.vertx.web.Param;
 import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
 import io.quarkus.vertx.web.RouteBase;
-import io.vertx.core.http.HttpMethod;
 
 @RouteBase(path = "/validate")
 public class ValidationOnRequestParamsRouteHandler {

--- a/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/validation/ValidationOnResponseRouteHandler.java
+++ b/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/validation/ValidationOnResponseRouteHandler.java
@@ -4,10 +4,10 @@ import javax.validation.Valid;
 import javax.validation.constraints.Size;
 
 import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.Route.HttpMethod;
 import io.quarkus.vertx.web.RouteBase;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
-import io.vertx.core.http.HttpMethod;
 
 @RouteBase(path = "/validate")
 public class ValidationOnResponseRouteHandler {

--- a/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/validation/ValidationOnResponseRouteHandler.java
+++ b/304-quarkus-vertx-routes/src/main/java/io/quarkus/qe/validation/ValidationOnResponseRouteHandler.java
@@ -6,7 +6,6 @@ import javax.validation.constraints.Size;
 import io.quarkus.vertx.web.Route;
 import io.quarkus.vertx.web.Route.HttpMethod;
 import io.quarkus.vertx.web.RouteBase;
-import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
 @RouteBase(path = "/validate")
@@ -31,14 +30,6 @@ public class ValidationOnResponseRouteHandler {
     @Size(min = 3, max = 3, message = "response must have 3 characters")
     Uni<String> validateUniResponseWithStringReturnsInvalidSize() {
         return Uni.createFrom().item("ASDASD");
-    }
-
-    @Route(methods = HttpMethod.GET, path = "/response-multi-invalid-id")
-    @Valid
-    Multi<Response> validateMultiResponseWithTypeReturnsInvalidID() {
-        Response response = createResponse();
-        response.setId(null); // it's not invalid!
-        return Multi.createFrom().items(response);
     }
 
     private static final Response createResponse() {

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnResponseRouteHandlerTest.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnResponseRouteHandlerTest.java
@@ -53,20 +53,4 @@ public class ValidationOnResponseRouteHandlerTest {
         assertValidationErrorDetails(response);
         assertValidationErrorStatus(response, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     }
-
-    @Disabled("Not validating when using Multi. Reported in: https://github.com/quarkusio/quarkus/issues/15166")
-    @Test
-    public void shouldGetValidationErrorWhenMultiResponseIdIsWrong() {
-        ValidationErrorResponse response = given()
-                .when()
-                .get("/validate/response-multi-invalid-id")
-                .then()
-                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-                .extract().as(ValidationErrorResponse.class);
-
-        assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
-        assertValidationErrorStatus(response, HttpStatus.SC_INTERNAL_SERVER_ERROR);
-        assertValidationErrorField(response, "id", "id can't be null");
-    }
 }

--- a/603-spring-web-smallrye-openapi/src/test/resources/request-types.csv
+++ b/603-spring-web-smallrye-openapi/src/test/resources/request-types.csv
@@ -1,13 +1,18 @@
+##
+## Lines starting with '#' are ignored.
+## All ignored lines fail due to https://github.com/quarkusio/quarkus/issues/16395.
+## TODO: Uncomment after resolution.
+##
 /delete-text-plain,delete,text/plain
 /delete/no-type,delete,application/json
-/delete/text-plain,delete,text/plain
+#/delete/text-plain,delete,text/plain
 /delete/json,delete,application/json
-/delete/octet-stream,delete,application/octet-stream
+#/delete/octet-stream,delete,application/octet-stream
 /patch-text-plain,patch,text/plain
 /patch/no-type,patch,application/json
-/patch/text-plain,patch,text/plain
+#/patch/text-plain,patch,text/plain
 /patch/json,patch,application/json
-/patch/octet-stream,patch,application/octet-stream
+#/patch/octet-stream,patch,application/octet-stream
 /post-text-plain,post,text/plain
 /post/no-type,post,application/json
 /post/text-plain,post,text/plain
@@ -15,6 +20,6 @@
 /post/octet-stream,post,application/octet-stream
 /put-text-plain,put,text/plain
 /put/no-type,put,application/json
-/put/text-plain,put,text/plain
+#/put/text-plain,put,text/plain
 /put/json,put,application/json
-/put/octet-stream,put,application/octet-stream
+#/put/octet-stream,put,application/octet-stream

--- a/603-spring-web-smallrye-openapi/src/test/resources/response-types.csv
+++ b/603-spring-web-smallrye-openapi/src/test/resources/response-types.csv
@@ -1,18 +1,23 @@
+##
+## Lines starting with '#' are ignored.
+## All ignored lines fail due to https://github.com/quarkusio/quarkus/issues/16395.
+## TODO: Uncomment after resolution.
+##
 /delete-text-plain,delete,text/plain
 /delete/no-type,delete,application/json
-/delete/text-plain,delete,text/plain
+#/delete/text-plain,delete,text/plain
 /delete/json,delete,application/json
-/delete/octet-stream,delete,application/octet-stream
+#/delete/octet-stream,delete,application/octet-stream
 /get-text-plain,get,text/plain
 /get/no-type,get,application/json
-/get/text-plain,get,text/plain
+#/get/text-plain,get,text/plain
 /get/json,get,application/json
-/get/octet-stream,get,application/octet-stream
+#/get/octet-stream,get,application/octet-stream
 /patch-text-plain,patch,text/plain
 /patch/no-type,patch,application/json
-/patch/text-plain,patch,text/plain
+#/patch/text-plain,patch,text/plain
 /patch/json,patch,application/json
-/patch/octet-stream,patch,application/octet-stream
+#/patch/octet-stream,patch,application/octet-stream
 /post-text-plain,post,text/plain
 /post/no-type,post,application/json
 /post/text-plain,post,text/plain
@@ -20,6 +25,6 @@
 /post/octet-stream,post,application/octet-stream
 /put-text-plain,put,text/plain
 /put/no-type,put,application/json
-/put/text-plain,put,text/plain
+#/put/text-plain,put,text/plain
 /put/json,put,application/json
-/put/octet-stream,put,application/octet-stream
+#/put/octet-stream,put,application/octet-stream

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,10 @@
       <module>004-quarkus-HHH-and-HV</module>
       <module>005-quarkus-and-maven-profiles</module>
       <module>006-quartz-manually-scheduled-job</module>
+      <!--
+      TODO: Disabled as it's not working using latest 999-SNAPSHOT. Caused by https://github.com/quarkusio/quarkus/issues/16386. 
       <module>009-quarkus-infinispan-grpc-kafka</module>
+       -->
       <module>010-quarkus-opentracing-reactive-grpc</module>
       <module>011-quarkus-panache-rest-flyway</module>
       <module>012-quarkus-kafka-streams</module>


### PR DESCRIPTION
Changes:
- Change HttpMethod to use the one from vertx route:
The reactive routes signature have changed and need to use another HttpMethod enum. More info in here: https://github.com/quarkusio/quarkus/commit/72da8546b564aa4871ea16aa4bf5b930f0f9286b

- Regression issue: Infinispan and Kafka extensions stopped working at the same time, reported by https://github.com/quarkusio/quarkus/issues/16386

- The annotation `@Health` got removed. I changed it to `@Readiness`. I've also added a new test case for covering the `HealthGroup` annotation and reported https://github.com/quarkusio/quarkus/issues/16389

- Regression Test: Validation errors on Reactive routes are no longer propagated. Reported by https://github.com/quarkusio/quarkus/issues/16430

- Regression issue: SmallRye OpenAPI generates incorrect content type when using Spring Web annotations. Reported by https://github.com/quarkusio/quarkus/issues/16395