### PR TITLE
Fix module 302 in Native

### DIFF
--- a/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/config/VertxAuthObjectMapperCustomizer.java
+++ b/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/config/VertxAuthObjectMapperCustomizer.java
@@ -1,0 +1,20 @@
+package io.quarkus.qe.vertx.web.config;
+
+import javax.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class VertxAuthObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        // Not fail on empty beans, otherwise the module fails on Native because:
+        // Failed to encode as JSON: No serializer found for class io.vertx.ext.auth.impl.UserImpl and no properties discovered to create
+        // BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
+        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    }
+}


### PR DESCRIPTION
This module was failing in Native because this exception:

```
{"timestamp":1618384522931,"status":500,"error":"Internal Server Error","path":"/bladeRunner/","message":"Failed to encode as JSON: No serializer found for class io.vertx.ext.auth.impl.UserImpl and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)"}
```

Note that I tried to approach this error following this guide: https://quarkus.io/guides/writing-native-applications-tips#using-the-registerforreflection-annotation

This means that I tried:
- Adding `@RegisterForReflection(targets=UserImpl.class)`
- And adding the `reflection-config.json` file

Any of these two approaches worked, but disabling the failures on empty beans. 