### PR TITLE
Add coverage for Rest Client Server Sent Events

### DIFF
--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/ServerSentEventsPingResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/ServerSentEventsPingResource.java
@@ -1,0 +1,28 @@
+package io.quarkus.qe.ping;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.quarkus.qe.ping.clients.ServerSentEventsPongClient;
+import io.quarkus.qe.traceable.TraceableResource;
+import io.smallrye.mutiny.Multi;
+
+@Path("/server-sent-events-ping")
+public class ServerSentEventsPingResource extends TraceableResource {
+
+    @Inject
+    @RestClient
+    ServerSentEventsPongClient pongClient;
+
+    @GET
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public Multi<String> getPing() {
+        recordTraceId();
+        return Multi.createFrom().publisher(pongClient.getPong()).map(response -> "ping " + response);
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/clients/ServerSentEventsPongClient.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/ping/clients/ServerSentEventsPongClient.java
@@ -1,0 +1,18 @@
+package io.quarkus.qe.ping.clients;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.reactivestreams.Publisher;
+
+@RegisterRestClient
+public interface ServerSentEventsPongClient {
+    @GET
+    @Path("/server-sent-events-pong")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    Publisher<String> getPong();
+
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/pong/ServerSentEventsPongResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/java/io/quarkus/qe/pong/ServerSentEventsPongResource.java
@@ -1,0 +1,20 @@
+package io.quarkus.qe.pong;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.quarkus.qe.traceable.TraceableResource;
+import io.smallrye.mutiny.Multi;
+
+@Path("/server-sent-events-pong")
+public class ServerSentEventsPongResource extends TraceableResource {
+
+    @GET
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public Multi<String> getPong() {
+        recordTraceId();
+        return Multi.createFrom().item("pong");
+    }
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/main/resources/application.properties
+++ b/010-quarkus-opentracing-reactive-grpc/src/main/resources/application.properties
@@ -14,5 +14,8 @@ io.quarkus.qe.ping.clients.PongClient/mp-rest/scope=javax.inject.Singleton
 io.quarkus.qe.ping.clients.ReactivePongClient/mp-rest/url=http://localhost:8081
 io.quarkus.qe.ping.clients.ReactivePongClient/mp-rest/scope=javax.inject.Singleton
 
+io.quarkus.qe.ping.clients.ServerSentEventsPongClient/mp-rest/url=http://localhost:8081
+io.quarkus.qe.ping.clients.ServerSentEventsPongClient/mp-rest/scope=javax.inject.Singleton
+
 # gRPC
 quarkus.grpc.clients.pong.host=localhost

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
@@ -2,7 +2,6 @@ package io.quarkus.qe;
 
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +33,7 @@ public abstract class AbstractPingPongResourceTest {
         given()
                 .when().get(pingEndpoint())
                 .then().statusCode(HttpStatus.SC_OK)
-                .body(is("ping pong"));
+                .body(containsString("ping pong"));
 
         // Then both ping and pong rest endpoints should have the same trace Id.
         String pingTraceId = given()

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeServerSentEventsPingPongResourceOpentracingIT.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeServerSentEventsPingPongResourceOpentracingIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeServerSentEventsPingPongResourceOpentracingIT extends ServerSentEventsPingPongResourceOpentracingTest {
+
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/ServerSentEventsPingPongResourceOpentracingTest.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/ServerSentEventsPingPongResourceOpentracingTest.java
@@ -1,0 +1,12 @@
+package io.quarkus.qe;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ServerSentEventsPingPongResourceOpentracingTest extends AbstractPingPongResourceTest {
+
+    @Override
+    protected String endpointPrefix() {
+        return "server-sent-events";
+    }
+}


### PR DESCRIPTION
From MicroProfile 4.0, RestClient now supports Server Sent Events using reactivestreams API.