### PR TITLE
Remove Vertx unused lib

### DIFF
--- a/302-quarkus-vertx-jwt/pom.xml
+++ b/302-quarkus-vertx-jwt/pom.xml
@@ -16,10 +16,6 @@
       <artifactId>vertx-auth-jwt</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-auth-common</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-web</artifactId>
     </dependency>

--- a/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/config/VertxAuthObjectMapperCustomizer.java
+++ b/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/config/VertxAuthObjectMapperCustomizer.java
@@ -12,9 +12,7 @@ public class VertxAuthObjectMapperCustomizer implements ObjectMapperCustomizer {
 
     @Override
     public void customize(ObjectMapper objectMapper) {
-        // Not fail on empty beans, otherwise the module fails on Native because:
-        // Failed to encode as JSON: No serializer found for class io.vertx.ext.auth.impl.UserImpl and no properties discovered to create
-        // BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
+        // TODO https://github.com/quarkusio/quarkus/issues/16555
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     }
 }


### PR DESCRIPTION
- Remove `io.vertx:vertx-auth-common` (not required on Quarkus 2.x)
- Add github issue related to Vertx auth.user serialization error. 