### PR TITLE
[1.11] Reproducer for QUARKUS-662: Inject of HttpSession throws exception

### DIFF
--- a/101-javaee-like-getting-started/README.md
+++ b/101-javaee-like-getting-started/README.md
@@ -7,7 +7,9 @@ Uses MP health (https://quarkus.io/guides/microprofile-health) and MP metrics (h
 Application:
 - Define greeting resource with metrics.
 - Define health checks.
+- Define a bean to inject scoped HTTP beans.
 
 Tests:
 - Test the health endpoints responses.
 - Test greeting resource endpoint response.
+- Reproducer for [QUARKUS-662](https://issues.redhat.com/browse/QUARKUS-662): "Injection of HttpSession throws UnsatisfiedResolutionException during the build phase" is covered by the test `InjectingScopedBeansResourceTest` and `NativeInjectingScopedBeansResourceIT`. 

--- a/101-javaee-like-getting-started/src/main/java/io/quarkus/qe/core/InjectingScopedBeansResource.java
+++ b/101-javaee-like-getting-started/src/main/java/io/quarkus/qe/core/InjectingScopedBeansResource.java
@@ -1,0 +1,44 @@
+package io.quarkus.qe.core;
+
+import javax.inject.Inject;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/scopedbeans")
+public class InjectingScopedBeansResource {
+
+    @Inject
+    HttpServletRequest request;
+
+    @Inject
+    HttpSession session;
+
+    @Inject
+    ServletContext context;
+
+    @GET
+    @Path("/sessionId")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String sessionId() {
+        return session.getId();
+    }
+
+    @GET
+    @Path("/requestId")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String requestId() {
+        return request.getSession().getId();
+    }
+
+    @GET
+    @Path("/contextPath")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String contextPath() {
+        return context.getContextPath();
+    }
+}

--- a/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/InjectingScopedBeansResourceTest.java
+++ b/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/InjectingScopedBeansResourceTest.java
@@ -1,0 +1,23 @@
+package io.quarkus.qe.core;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class InjectingScopedBeansResourceTest {
+    @Test
+    public void shouldInjectScopedBeans() {
+        given().when().get("/scopedbeans/sessionId")
+                .then().body(notNullValue());
+
+        given().when().get("/scopedbeans/requestId")
+                .then().body(notNullValue());
+
+        given().get("/scopedbeans/contextPath")
+                .then().body(notNullValue());
+    }
+}

--- a/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeInjectingScopedBeansResourceIT.java
+++ b/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeInjectingScopedBeansResourceIT.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe.core;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeInjectingScopedBeansResourceIT extends InjectingScopedBeansResourceTest {
+
+}


### PR DESCRIPTION
Reproducer for https://issues.redhat.com/browse/QUARKUS-662: "Injection of HttpSession throws UnsatisfiedResolutionException during the build phase" is covered by the test `InjectingScopedBeansResourceTest` and `NativeInjectingScopedBeansResourceIT`.