### PR TITLE
Maven 3.8.1 doesn't support insecured paths

### DIFF
--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -15,7 +15,7 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Update confluent maven repository URL in order to be supported by Maven 3.8.1