### PR TITLE
Remove workaround for Vert.x Routes to map to JSON

### DIFF
--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnRequestBodyRouteHandlerTest.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnRequestBodyRouteHandlerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.validation.utils.ValidationErrorResponse;
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.http.ContentType;
 import io.vertx.core.json.Json;
 
 @QuarkusTest
@@ -22,8 +21,7 @@ public class ValidationOnRequestBodyRouteHandlerTest {
         Request request = new Request();
         request.setFirstCode("MA");
 
-        // TODO: Added workaround ".accept(ContentType.JSON)" to get a JSON response. Reported by https://github.com/quarkusio/quarkus/issues/15159
-        ValidationErrorResponse response = given().accept(ContentType.JSON)
+        ValidationErrorResponse response = given()
                 .when()
                 .body(Json.encode(request))
                 .post("/validate/request-body")
@@ -44,8 +42,7 @@ public class ValidationOnRequestBodyRouteHandlerTest {
         request.setFirstCode("MA");
         request.setSecondCode("F12");
 
-        // TODO: Added workaround ".accept(ContentType.JSON)" to get a JSON response. Reported by https://github.com/quarkusio/quarkus/issues/15159
-        ValidationErrorResponse response = given().accept(ContentType.JSON)
+        ValidationErrorResponse response = given()
                 .body(Json.encode(request))
                 .post("/validate/request-body")
                 .then()
@@ -65,8 +62,7 @@ public class ValidationOnRequestBodyRouteHandlerTest {
         request.setSecondCode("FR123");
         request.setCustom("lower");
 
-        // TODO: Added workaround ".accept(ContentType.JSON)" to get a JSON response. Reported by https://github.com/quarkusio/quarkus/issues/15159
-        ValidationErrorResponse response = given().accept(ContentType.JSON)
+        ValidationErrorResponse response = given()
                 .when()
                 .body(Json.encode(request))
                 .post("/validate/request-body")

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnRequestParamRouteHandlerTest.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnRequestParamRouteHandlerTest.java
@@ -11,15 +11,13 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.validation.utils.ValidationErrorResponse;
 import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class ValidationOnRequestParamRouteHandlerTest {
 
     @Test
     public void shouldGetValidationErrorWhenSingleParamIsWrong() {
-        // TODO: Added workaround ".accept(ContentType.JSON)" to get a JSON response. Reported by https://github.com/quarkusio/quarkus/issues/15159
-        ValidationErrorResponse response = given().accept(ContentType.JSON)
+        ValidationErrorResponse response = given()
                 .when()
                 .get("/validate/request-single-param/MA")
                 .then()
@@ -42,8 +40,7 @@ public class ValidationOnRequestParamRouteHandlerTest {
 
     @Test
     public void shouldGetValidationErrorsWhenAllParamsAreWrong() {
-        // TODO: Added workaround ".accept(ContentType.JSON)" to get a JSON response. Reported by https://github.com/quarkusio/quarkus/issues/15159
-        ValidationErrorResponse response = given().accept(ContentType.JSON)
+        ValidationErrorResponse response = given()
                 .get("/validate/request-multiple-param/MA/second/F12")
                 .then()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
@@ -65,8 +62,7 @@ public class ValidationOnRequestParamRouteHandlerTest {
 
     @Test
     public void shouldGetValidationErrorWhenSingleParamIsLowercase() {
-        // TODO: Added workaround ".accept(ContentType.JSON)" to get a JSON response. Reported by https://github.com/quarkusio/quarkus/issues/15159
-        ValidationErrorResponse response = given().accept(ContentType.JSON)
+        ValidationErrorResponse response = given()
                 .when()
                 .get("/validate/request-single-param-custom-validation/lower")
                 .then()


### PR DESCRIPTION
The issue https://github.com/quarkusio/quarkus/issues/15159 has been resolved in Quarkus upstream, so we can remove the workarounds that force mapping routes to JSON. This verifies that the issue is gone.