### PR TITLE
Update formatter rules to validate `io` packages, avoid import stars and fixed when selecting Maven profiles

### DIFF
--- a/301-quarkus-vertx-kafka/src/main/java/io/quarkus/qe/kafka/consumer/KStockPriceConsumer.java
+++ b/301-quarkus-vertx-kafka/src/main/java/io/quarkus/qe/kafka/consumer/KStockPriceConsumer.java
@@ -5,7 +5,12 @@ import java.util.function.BiConsumer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.reactive.messaging.*;
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.OnOverflow;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.jboss.logging.Logger;
 
 import io.quarkus.qe.kafka.StockPrice;

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="severity" value="error"/>
+    <module name="TreeWalker">
+        <!-- Checks for imports                              -->
+        <!-- See https://checkstyle.org/config_imports.html -->
+        <module name="AvoidStarImport"/>
+        <module name="RedundantImport"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.0</impsort-maven-plugin.version>
         <xml-format-maven-plugin>3.1.2</xml-format-maven-plugin>
+        <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
@@ -205,6 +206,28 @@
                                 <exclude>**/quarkus/**/*.xml</exclude>
                             </excludes>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <linkXRef>true</linkXRef>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
                 <configuration>
                     <!-- store outside of target to speed up formatting when mvn clean is used -->
                     <cachedir>.cache</cachedir>
-                    <groups>java.,javax.,org.,com.</groups>
+                    <groups>java.,javax.,org.,com.,io.</groups>
                     <staticGroups>*</staticGroups>
                     <removeUnused>true</removeUnused>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>999-SNAPSHOT</quarkus-plugin.version>
+        <!-- Default values for format -->
+        <src.format.goal>format</src.format.goal>
+        <src.sort.goal>sort</src.sort.goal>
+        <xml.format.goal>xml-format</xml.format.goal>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -249,17 +253,6 @@
             </build>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
-            </properties>
-        </profile>
-        <profile>
-            <id>format</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <src.format.goal>format</src.format.goal>
-                <src.sort.goal>sort</src.sort.goal>
-                <xml.format.goal>xml-format</xml.format.goal>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
- Update import rules to validate io packages at the end
- Fix formatter when using Maven profiles
At the moment, it was failing when selecting Maven profiles because the `format` profile was unselected and hence the properties were not present.

- Add Checkstyle to avoid import statements that use the * notation.