### PR TITLE
Replaced deprecated Quartz Store Type to JDBC-CMT

### DIFF
--- a/006-quartz-manually-scheduled-job/src/main/resources/application.properties
+++ b/006-quartz-manually-scheduled-job/src/main/resources/application.properties
@@ -5,7 +5,7 @@ quarkus.datasource.jdbc.max-size=8
 quarkus.datasource.jdbc.min-size=2
 
 # Quartz configuration
-quarkus.quartz.store-type=db
+quarkus.quartz.store-type=jdbc-cmt
 quarkus.quartz.clustered=true
 
 # flyway to create Quartz tables


### PR DESCRIPTION
The "db" value has been deprecated as part of https://github.com/quarkusio/quarkus/commit/66a0191ffab01cd5b2c5320756bdbfc94c85314c