### PR TITLE
Kafka 2.7 migration

### DIFF
--- a/009-quarkus-infinispan-grpc-kafka/pom.xml
+++ b/009-quarkus-infinispan-grpc-kafka/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>
-            <artifactId>test-container</artifactId>
+            <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/ConfluentKafkaTestResource.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/ConfluentKafkaTestResource.java
@@ -16,7 +16,7 @@ public class ConfluentKafkaTestResource implements QuarkusTestResourceLifecycleM
 
     @Override
     public Map<String, String> start() {
-        container = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+        container = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.1.1"));
         container.start();
 
         final String hosts = container.getContainerIpAddress() + ":" + container.getMappedPort(KafkaContainer.KAFKA_PORT);

--- a/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/StrimziKafkaResource.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/StrimziKafkaResource.java
@@ -17,7 +17,7 @@ public class StrimziKafkaResource implements QuarkusTestResourceLifecycleManager
     @Override
     public Map<String, String> start() {
         Network network = Network.newNetwork();
-        kafkaContainer = new StrimziKafkaContainer("0.18.0-kafka-2.5.0").withNetwork(network);
+        kafkaContainer = new StrimziKafkaContainer("latest-kafka-2.7.0").withNetwork(network);
         kafkaContainer.start();
 
         String kafkaUrl = kafkaContainer.getBootstrapServers();

--- a/012-quarkus-kafka-streams/pom.xml
+++ b/012-quarkus-kafka-streams/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>
-            <artifactId>test-container</artifactId>
+            <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/012-quarkus-kafka-streams/src/test/java/io/quarkus/qe/StrimziKafkaResource.java
+++ b/012-quarkus-kafka-streams/src/test/java/io/quarkus/qe/StrimziKafkaResource.java
@@ -17,7 +17,7 @@ public class StrimziKafkaResource implements QuarkusTestResourceLifecycleManager
     @Override
     public Map<String, String> start() {
         Network network = Network.newNetwork();
-        kafkaContainer = new StrimziKafkaContainer("0.18.0-kafka-2.5.0").withNetwork(network);
+        kafkaContainer = new StrimziKafkaContainer("latest-kafka-2.7.0").withNetwork(network);
         kafkaContainer.start();
 
         String kafkaUrl = kafkaContainer.getBootstrapServers();

--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>
-            <artifactId>test-container</artifactId>
+            <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -77,26 +77,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro-maven-plugin</artifactId>
-                <version>1.9.2</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>schema</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirectory>src/main/avro</sourceDirectory>
-                            <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
-                            <stringType>String</stringType>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/resources/ConfluentKafkaResource.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/resources/ConfluentKafkaResource.java
@@ -23,8 +23,8 @@ public class ConfluentKafkaResource implements QuarkusTestResourceLifecycleManag
     @Override
     public Map<String, String> start() {
         Network network = Network.newNetwork();
-        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.3.0")).withNetwork(network);
-        schemaRegistry = new SchemaRegistryContainer("confluentinc/cp-schema-registry", "5.3.0", 8081).withNetwork(network)
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.1.1")).withNetwork(network);
+        schemaRegistry = new SchemaRegistryContainer("confluentinc/cp-schema-registry", "6.1.1", 8081).withNetwork(network)
                 .withKafka(kafkaContainer, 9092);
 
         Startables.deepStart(Stream.of(kafkaContainer, schemaRegistry)).join();

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/resources/StrimziKafkaResource.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/resources/StrimziKafkaResource.java
@@ -23,7 +23,7 @@ public class StrimziKafkaResource implements QuarkusTestResourceLifecycleManager
     public Map<String, String> start() {
         Network network = Network.newNetwork();
 
-        kafkaContainer = new StrimziKafkaContainer("0.18.0-kafka-2.5.0").withNetwork(network);
+        kafkaContainer = new StrimziKafkaContainer("latest-kafka-2.7.0").withNetwork(network);
         schemaRegistry = new SchemaRegistryContainer("apicurio/apicurio-registry-mem", "1.2.2.Final", 8080).withNetwork(network)
                 .withKafka(kafkaContainer, 9092);
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <testcontainers.version>1.15.2</testcontainers.version>
-        <strimzi.testcontainers.version>0.20.0</strimzi.testcontainers.version>
+        <strimzi.testcontainers.version>0.22.1</strimzi.testcontainers.version>
         <wiremock.version>2.27.2</wiremock.version>
         <apicurio-registry-utils-serde.version>1.3.2.Final</apicurio-registry-utils-serde.version>
         <confluent.kafka-avro-serializer.version>6.0.0</confluent.kafka-avro-serializer.version>
@@ -81,7 +81,7 @@
             </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>
-                <artifactId>test-container</artifactId>
+                <artifactId>strimzi-test-container</artifactId>
                 <version>${strimzi.testcontainers.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
                     <execution>
                         <goals>
                             <goal>build</goal>
+                            <goal>generate-code</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
- Move on to Kafka 2.7
         -   `confluentinc/cp-kafka:6.1.1` is poing to [Kafka 2.7](https://docs.confluent.io/platform/current/installation/versions-interoperability.html)
         - Strimzi: `latest-kafka-2.7.0`
- Remove Avro Kafka plugin ([Not required anymore](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.0#avro))