### PR TITLE
[1.11] Upgrade to Kafka 2.7

### DIFF
--- a/009-quarkus-infinispan-grpc-kafka/pom.xml
+++ b/009-quarkus-infinispan-grpc-kafka/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>io.strimzi</groupId>
-            <artifactId>test-container</artifactId>
+            <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/ConfluentKafkaTestResource.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/ConfluentKafkaTestResource.java
@@ -16,7 +16,7 @@ public class ConfluentKafkaTestResource implements QuarkusTestResourceLifecycleM
 
     @Override
     public Map<String, String> start() {
-        container = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+        container = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.1.1"));
         container.start();
 
         final String hosts = container.getContainerIpAddress() + ":" + container.getMappedPort(KafkaContainer.KAFKA_PORT);

--- a/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/StrimziKafkaResource.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/StrimziKafkaResource.java
@@ -17,7 +17,7 @@ public class StrimziKafkaResource implements QuarkusTestResourceLifecycleManager
     @Override
     public Map<String, String> start() {
         Network network = Network.newNetwork();
-        kafkaContainer = new StrimziKafkaContainer("0.18.0-kafka-2.5.0").withNetwork(network);
+        kafkaContainer = new StrimziKafkaContainer("latest-kafka-2.7.0").withNetwork(network);
         kafkaContainer.start();
 
         String kafkaUrl = kafkaContainer.getBootstrapServers();

--- a/012-quarkus-kafka-streams/pom.xml
+++ b/012-quarkus-kafka-streams/pom.xml
@@ -37,7 +37,7 @@
 
         <dependency>
             <groupId>io.strimzi</groupId>
-            <artifactId>test-container</artifactId>
+            <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/012-quarkus-kafka-streams/src/test/java/io/quarkus/qe/StrimziKafkaResource.java
+++ b/012-quarkus-kafka-streams/src/test/java/io/quarkus/qe/StrimziKafkaResource.java
@@ -16,7 +16,7 @@ public class StrimziKafkaResource implements QuarkusTestResourceLifecycleManager
     @Override
     public Map<String, String> start() {
         Network network = Network.newNetwork();
-        kafkaContainer = new StrimziKafkaContainer("0.18.0-kafka-2.5.0").withNetwork(network);
+        kafkaContainer = new StrimziKafkaContainer("latest-kafka-2.7.0").withNetwork(network);
         kafkaContainer.start();
 
         String kafkaUrl = kafkaContainer.getBootstrapServers();

--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -61,7 +61,7 @@
 
         <dependency>
             <groupId>io.strimzi</groupId>
-            <artifactId>test-container</artifactId>
+            <artifactId>strimzi-test-container</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/vertx/kafka/ConfluentKafkaResource.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/vertx/kafka/ConfluentKafkaResource.java
@@ -1,15 +1,17 @@
 package io.quarkus.qe.vertx.kafka;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import org.jboss.logging.Logger;
-import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.lifecycle.Startables;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class ConfluentKafkaResource implements QuarkusTestResourceLifecycleManager {
 
@@ -21,8 +23,9 @@ public class ConfluentKafkaResource implements QuarkusTestResourceLifecycleManag
     @Override
     public Map<String, String> start() {
         Network network = Network.newNetwork();
-        kafkaContainer = new KafkaContainer("5.3.0").withNetwork(network);
-        schemaRegistry = new SchemaRegistryContainer("confluentinc/cp-schema-registry","5.3.0", 8081).withNetwork(network).withKafka(kafkaContainer, 9092);
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.1.1")).withNetwork(network);
+        schemaRegistry = new SchemaRegistryContainer("confluentinc/cp-schema-registry", "6.1.1", 8081).withNetwork(network)
+                .withKafka(kafkaContainer, 9092);
 
         Startables.deepStart(Stream.of(kafkaContainer, schemaRegistry)).join();
 

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/vertx/kafka/StrimziKafkaResource.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/vertx/kafka/StrimziKafkaResource.java
@@ -22,8 +22,9 @@ public class StrimziKafkaResource implements QuarkusTestResourceLifecycleManager
     public Map<String, String> start() {
         Network network = Network.newNetwork();
 
-        kafkaContainer = new StrimziKafkaContainer("0.18.0-kafka-2.5.0").withNetwork(network);
-        schemaRegistry = new SchemaRegistryContainer("apicurio/apicurio-registry-mem", "1.2.2.Final", 8080).withNetwork(network).withKafka(kafkaContainer, 9092);
+        kafkaContainer = new StrimziKafkaContainer("latest-kafka-2.7.0").withNetwork(network);
+        schemaRegistry = new SchemaRegistryContainer("apicurio/apicurio-registry-mem", "1.2.2.Final", 8080).withNetwork(network)
+                .withKafka(kafkaContainer, 9092);
 
         Startables.deepStart(Stream.of(kafkaContainer, schemaRegistry)).join();
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <testcontainers.version>1.15.2</testcontainers.version>
-    <strimzi.testcontainers.version>0.20.0</strimzi.testcontainers.version>
+    <strimzi.testcontainers.version>0.22.1</strimzi.testcontainers.version>
     <wiremock.version>2.27.2</wiremock.version>
     <apicurio-registry-utils-serde.version>1.2.2.Final</apicurio-registry-utils-serde.version>
     <confluent.kafka-avro-serializer.version>6.0.0</confluent.kafka-avro-serializer.version>
@@ -86,7 +86,7 @@
       </dependency>
       <dependency>
         <groupId>io.strimzi</groupId>
-        <artifactId>test-container</artifactId>
+        <artifactId>strimzi-test-container</artifactId>
         <version>${strimzi.testcontainers.version}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
backport of #201 

Note: this commit `90f053f` wasn't backported because doesn't apply to version 1.11