### PR TITLE
Open telemetry throw a Random/SplittableRandom initialized error 

### DIFF
--- a/300-quarkus-vertx-webClient/pom.xml
+++ b/300-quarkus-vertx-webClient/pom.xml
@@ -8,14 +8,15 @@
     </parent>
     <artifactId>300-quarkus-vertx-webclient</artifactId>
     <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>
-        </dependency>
+        <!-- TODO: https://github.com/quarkusio/quarkus/issues/17234 -->
+        <!--  <dependency>-->
+        <!--  <groupId>io.quarkus</groupId>-->
+        <!--  <artifactId>quarkus-opentelemetry</artifactId>-->
+        <!--  </dependency>-->
+        <!--  <dependency>-->
+        <!--  <groupId>io.quarkus</groupId>-->
+        <!--  <artifactId>quarkus-opentelemetry-exporter-jaeger</artifactId>-->
+        <!--  </dependency>-->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-web</artifactId>

--- a/300-quarkus-vertx-webClient/src/main/resources/application.properties
+++ b/300-quarkus-vertx-webClient/src/main/resources/application.properties
@@ -5,7 +5,7 @@ vertx.webclient.timeout-sec=2
 vertx.webclient.retries=3
 
 # Jaeger
-quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250/api/traces
+# quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250/api/traces
 
 # debug symbols enabled
 quarkus.native.debug.enabled=true

--- a/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceTest.java
+++ b/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceTest.java
@@ -87,6 +87,8 @@ public class ChuckNorrisResourceTest {
     }
 
     @Test
+    // TODO: https://github.com/quarkusio/quarkus/issues/17234
+    @Disabled
     public void endpointShouldTrace() {
         final int pageLimit = 50;
         final String expectedOperationName = "trace/ping";

--- a/300-quarkus-vertx-webClient/src/test/resources/application.properties
+++ b/300-quarkus-vertx-webClient/src/test/resources/application.properties
@@ -7,4 +7,5 @@ vertx.webclient.timeout-sec=1
 vertx.webclient.retries=1
 
 # Jaeger
-quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250/api/traces
+# TODO: https://github.com/quarkusio/quarkus/issues/17234
+# quarkus.opentelemetry.tracer.exporter.jaeger.endpoint=http://localhost:14250/api/traces


### PR DESCRIPTION
Disabled open telemetry extensions, because is throwing a Random/SplittableRandom
initialized error on build time

Issue Ref: https://github.com/quarkusio/quarkus/issues/17234