### PR TITLE
Add coverage for `@ConfigMapping` annotation

### DIFF
--- a/022-quarkus-properties-config-all/README.md
+++ b/022-quarkus-properties-config-all/README.md
@@ -24,6 +24,8 @@ supported classes (e.x. String, Boolean, Double, etc.)
 
 6. Injecting a `ConfigValue` instance that was introduced in MicroProfile Config 2.0
 
+7. Injecting properties using the `@ConfigMapping` annotation. More info in: https://smallrye.io/docs/smallrye-config/mapping/mapping.html
+
 ___
 #### Wiki:
 **Protagonist**: the leading character in the story, whose purpose is to move story to its final  

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/ConfigMappingResource.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/ConfigMappingResource.java
@@ -1,0 +1,63 @@
+package io.quarkus.qe.configmapping;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import io.smallrye.config.ConfigMapping;
+
+@Path("/config-mapping")
+public class ConfigMappingResource {
+    @Inject
+    Person personField;
+
+    @Inject
+    @ConfigMapping(prefix = "overrides.person")
+    Person personOverridesField;
+
+    @Inject
+    PersonInterface personInterface;
+
+    @GET
+    @Path("/person/name/from-field")
+    public String getPersonNameFromField() {
+        return personField.name;
+    }
+
+    @GET
+    @Path("/person/age/from-field")
+    public int getPersonAgeFromField() {
+        return personField.age;
+    }
+
+    @GET
+    @Path("/person/name/from-overrides-field")
+    public String getPersonNameFromOverridesField() {
+        return personOverridesField.name;
+    }
+
+    @GET
+    @Path("/person/age/from-overrides-field")
+    public int getPersonAgeFromOverridesField() {
+        return personOverridesField.age;
+    }
+
+    @GET
+    @Path("/person/name/from-interface")
+    public String getPersonNameFromInterface() {
+        return personInterface.name();
+    }
+
+    @GET
+    @Path("/person/age/from-interface")
+    public int getPersonAgeFromInterface() {
+        return personInterface.age();
+    }
+
+    @GET
+    @Path("/person/label/{labelKey}/from-interface")
+    public String getPersonLabelFromInterface(@PathParam("labelKey") String labelKey) {
+        return personInterface.labels().get(labelKey);
+    }
+}

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/Person.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/Person.java
@@ -1,0 +1,9 @@
+package io.quarkus.qe.configmapping;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "person")
+public class Person {
+    String name;
+    int age;
+}

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/PersonInterface.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/PersonInterface.java
@@ -1,0 +1,14 @@
+package io.quarkus.qe.configmapping;
+
+import java.util.Map;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "person")
+public interface PersonInterface {
+    String name();
+
+    int age();
+
+    Map<String, String> labels();
+}

--- a/022-quarkus-properties-config-all/src/main/resources/application.properties
+++ b/022-quarkus-properties-config-all/src/main/resources/application.properties
@@ -20,3 +20,13 @@ server.url.composed=http://${server.host}:${server.port}/${server.path}
 
 # no substitution
 server.url.raw=\\${server.host}
+
+# Person
+person.name=Sheldon
+person.age=18
+person.labels.A=Label 1
+person.labels.B=Label 2
+
+# Overridden Person
+overrides.person.name=Karen
+overrides.person.age=23

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/ConfigMappingResourceTest.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/ConfigMappingResourceTest.java
@@ -1,0 +1,46 @@
+package io.quarkus.qe.configmapping;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class ConfigMappingResourceTest {
+
+    private static final String EXPECTED_PERSON_NAME = "Sheldon";
+    private static final int EXPECTED_PERSON_AGE = 18;
+    private static final String EXPECTED_PERSON_LABEL_A = "Label 1";
+    private static final String EXPECTED_PERSON_LABEL_B = "Label 2";
+    private static final String EXPECTED_OVERRIDES_PERSON_NAME = "Karen";
+    private static final int EXPECTED_OVERRIDES_PERSON_AGE = 23;
+
+    @Test
+    public void shouldInjectFieldWithConfigMapping() {
+        assertResponseIs("/person/name/from-field", EXPECTED_PERSON_NAME);
+        assertResponseIs("/person/age/from-field", EXPECTED_PERSON_AGE);
+    }
+
+    @Test
+    public void shouldInjectFieldUsingOverriddenConfigWithConfigMapping() {
+        assertResponseIs("/person/name/from-overrides-field", EXPECTED_OVERRIDES_PERSON_NAME);
+        assertResponseIs("/person/age/from-overrides-field", EXPECTED_OVERRIDES_PERSON_AGE);
+    }
+
+    @Test
+    public void shouldInjectInterfaceWithConfigMapping() {
+        assertResponseIs("/person/name/from-interface", EXPECTED_PERSON_NAME);
+        assertResponseIs("/person/age/from-interface", EXPECTED_PERSON_AGE);
+        assertResponseIs("/person/label/A/from-interface", EXPECTED_PERSON_LABEL_A);
+        assertResponseIs("/person/label/B/from-interface", EXPECTED_PERSON_LABEL_B);
+    }
+
+    private <T> void assertResponseIs(String path, T expected) {
+        given().when().get("/config-mapping" + path)
+                .then().statusCode(HttpStatus.SC_OK)
+                .body(is(expected.toString()));
+    }
+}

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/NativeConfigMappingResourceIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/NativeConfigMappingResourceIT.java
@@ -1,0 +1,7 @@
+package io.quarkus.qe.configmapping;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NativeConfigMappingResourceIT extends ConfigMappingResourceTest {
+}


### PR DESCRIPTION
Examples are inspired by https://github.com/smallrye/smallrye-config/blob/main/cdi/src/test/java/io/smallrye/config/inject/ConfigMappingInjectionTest.java
More info about this annotation: https://smallrye.io/docs/smallrye-config/mapping/mapping.html