### PR TITLE
[1.11] Agroal DB pool test coverage

### DIFF
--- a/014-quarkus-panache-with-transactions-xa/README.md
+++ b/014-quarkus-panache-with-transactions-xa/README.md
@@ -16,3 +16,5 @@ Additional UserEntity is a simple JPA entity that was created with aim to avoid 
 and instead test the additional combination of JPA entity + PanacheRepository + PanacheRepositoryResource, where
 PanacheRepository is a facade class. Facade class can override certain methods to change the default behaviour of the
 PanacheRepositoryResource methods.
+
+- AgroalPoolTest, will cover how the db pool is managed in terms of IDLE-timeout, max connections and concurrency. 

--- a/014-quarkus-panache-with-transactions-xa/src/main/resources/application.properties
+++ b/014-quarkus-panache-with-transactions-xa/src/main/resources/application.properties
@@ -17,3 +17,16 @@ quarkus.datasource.with-xa.jdbc.transactions=xa
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+%mysql_pool_test.quarkus.datasource.db-kind=mysql
+%mysql_pool_test.quarkus.datasource.username=sarah
+%mysql_pool_test.quarkus.datasource.password=connor
+%mysql_pool_test.quarkus.datasource.jdbc.url=jdbc:mysql://localhost:3306/db?currentSchema=test
+%mysql_pool_test.quarkus.datasource.jdbc.transactions=enabled
+%mysql_pool_test.quarkus.datasource.jdbc.max-size=3
+%mysql_pool_test.quarkus.datasource.jdbc.min-size=1
+%mysql_pool_test.quarkus.datasource.jdbc.background-validation-interval=1S
+%mysql_pool_test.quarkus.datasource.jdbc.idle-removal-interval=1S
+%mysql_pool_test.quarkus.datasource.jdbc.acquisition-timeout=60S
+%mysql_pool_test.quarkus.datasource.jdbc.validation-query-sql=SELECT CURRENT_TIMESTAMP
+%mysql_pool_test.quarkus.datasource.jdbc.new-connection-sql=SELECT CURRENT_TIMESTAMP

--- a/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/containers/MySqlDatabaseTestResource.java
+++ b/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/containers/MySqlDatabaseTestResource.java
@@ -25,7 +25,8 @@ public class MySqlDatabaseTestResource implements QuarkusTestResourceLifecycleMa
 
     @Override
     public Map<String, String> start() {
-        container = new MySQLContainer<>(DockerImageName.parse("mysql/mysql-server:8.0.22").asCompatibleSubstituteFor(MYSQL));
+        container = new MySQLContainer<>(
+                DockerImageName.parse("quay.io/bitnami/mysql:5.7.32").asCompatibleSubstituteFor(MYSQL));
         container.withUrlParam("currentSchema", DEFAULT_SCHEMA);
         container.start();
 

--- a/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/containers/MysqlTestProfile.java
+++ b/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/containers/MysqlTestProfile.java
@@ -1,0 +1,21 @@
+package io.quarkus.qe.containers;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class MysqlTestProfile implements QuarkusTestProfile {
+
+    public static final String PROFILE = "mysql_pool_test";
+
+    @Override
+    public String getConfigProfile() {
+        return PROFILE;
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        return Collections.singletonList(new TestResourceEntry(MySqlDatabaseTestResource.class));
+    }
+}

--- a/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/dbpool/AgroalPoolTest.java
+++ b/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/dbpool/AgroalPoolTest.java
@@ -1,0 +1,174 @@
+package io.quarkus.qe.dbpool;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.apache.http.HttpStatus;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.qe.containers.MysqlTestProfile;
+import io.quarkus.qe.rest.data.UserRepository;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.smallrye.mutiny.tuples.Tuple2;
+
+/**
+ * The aim of these tests is verified agroal and entityManager pool management
+ * Some of these tests required some extra load, in order to reproduce concurrency issues.
+ */
+@QuarkusTest
+@TestProfile(MysqlTestProfile.class)
+public class AgroalPoolTest {
+
+    private final int CONCURRENCY_LEVEL = 20;
+    private static final int TIMEOUT_SEC = 30;
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    UserRepository users;
+
+    @Inject
+    AgroalDataSource agroalDataSource;
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.idle-removal-interval")
+    String idleSec;
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.max-size")
+    int datasourceMaxSize;
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.min-size")
+    int datasourceMinSize;
+
+    @Test
+    @Disabled("Pending Zulip conversation about quarkus.datasource.jdbc.idle-removal-interval")
+    public void idleTimeoutTest() throws InterruptedException {
+        makeApplicationQuery();
+        Thread.sleep(Duration.ofMillis(getIdleMs() + 1).toMillis());
+        assertEquals(1, activeConnections(), "agroalCheckIdleTimeout: Expected " + datasourceMinSize + " active connections");
+    }
+
+    @Test
+    public void poolTurnoverTest() throws InterruptedException {
+        final int events = 500;
+        final AtomicInteger max = new AtomicInteger(0);
+
+        AssertSubscriber<Tuple2<Long, Long>> subscriber = Multi.createBy().combining()
+                .streams(makeApplicationQueryAsync(events), activeConnectionsAsync(events))
+                .asTuple().subscribe().withSubscriber(AssertSubscriber.create(events)).await().assertCompleted();
+
+        subscriber.getItems().forEach(t -> {
+            Long activeCon = t.getItem2();
+            if (max.intValue() < activeCon) {
+                max.set(activeCon.intValue());
+            }
+            assertTrue(datasourceMaxSize >= activeCon, "More mysql SQL connections than pool max-size");
+            assertTrue(datasourceMinSize <= activeCon, "Less mysql SQL connections than pool min-size");
+        });
+    }
+
+    @RepeatedTest(500)
+    public void borderConditionBetweenIdleAndGetConnectionTest() {
+        List<Uni<Integer>> pendingRequests = new ArrayList<>();
+        IntStream.range(0, CONCURRENCY_LEVEL).forEach(i -> pendingRequests.add(Uni.createFrom().item(makeApplicationQuery())));
+
+        Uni.combine()
+                .all()
+                .unis(pendingRequests)
+                .combinedWith(resp -> resp.stream().map(Integer.class::cast).collect(Collectors.toList()))
+                .await().atMost(Duration.ofSeconds(TIMEOUT_SEC))
+                .forEach(statusCode -> assertEquals(statusCode, HttpStatus.SC_OK, "Unexpected Application response"));
+    }
+
+    @RepeatedTest(100)
+    public void concurrentLoadTest() {
+        Multi.createFrom()
+                .range(0, CONCURRENCY_LEVEL).subscribe()
+                .with(n -> assertEquals(2, users.count(), "UnexpectedUser Amount"));
+    }
+
+    @RepeatedTest(500)
+    public void connectionConcurrencyTest() {
+        List<Uni<String>> pendingRequests = new ArrayList<>();
+        IntStream.range(0, CONCURRENCY_LEVEL).forEach(i -> pendingRequests.add(Uni.createFrom().item(makeAgroalRawQuery())));
+
+        Uni.combine()
+                .all()
+                .unis(pendingRequests)
+                .combinedWith(resp -> resp.stream().map(String.class::cast).collect(Collectors.toList()))
+                .await().atMost(Duration.ofSeconds(TIMEOUT_SEC))
+                .forEach(currentTime -> assertFalse(currentTime.isEmpty(), "Unexpected Application response"));
+    }
+
+    private long getIdleMs() {
+        int idle = Integer.parseInt(idleSec.replaceAll("[A-Z]", ""));
+        return Duration.ofSeconds(idle).toMillis();
+    }
+
+    private Multi<Long> activeConnectionsAsync(int events) {
+        return Multi.createFrom().range(0, events).onItem().transform(i -> activeConnections());
+    }
+
+    private Multi<Long> makeApplicationQueryAsync(int events) {
+        return Multi.createFrom().range(0, events).onItem().transform(i -> {
+            makeApplicationQuery();
+            return 0L;
+        });
+    }
+
+    private Long activeConnections() {
+        Query query = em.createNativeQuery("select * from INFORMATION_SCHEMA.PROCESSLIST;");
+        return (long) query.getResultList().size();
+    }
+
+    private int makeApplicationQuery() {
+        return given()
+                .accept("application/hal+json")
+                .when().get("/users/all")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .extract().response().statusCode();
+    }
+
+    private String makeAgroalRawQuery() {
+        String currentTime = "";
+        try {
+            Connection con = agroalDataSource.getConnection();
+            ResultSet rs = con.createStatement().executeQuery("SELECT CURRENT_TIMESTAMP");
+            rs.next();
+            currentTime = rs.getString(1);
+            rs.close();
+            con.close();
+        } catch (SQLException e) {
+            assertNull(e.getCause(), "makeAgroalRawQuery: Agroal datasource/poolImpl unexpected error");
+        }
+
+        return currentTime;
+    }
+}

--- a/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/rest/data/UserResourceTest.java
+++ b/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/rest/data/UserResourceTest.java
@@ -4,9 +4,9 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.containers.MySqlDatabaseTestResource;
@@ -30,7 +30,7 @@ class UserResourceTest {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .extract().response().jsonPath().getString("_embedded.user_list.name");
-        Assert.assertEquals("[Alaba, Balaba]", userList);
+        assertEquals("[Alaba, Balaba]", userList);
 
         //POST - Create a new User
         given()


### PR DESCRIPTION
backport: #203 

On Quarkus 1.11 `AssertSubscriber` object doesn't support await(int amount) so the test was re-written. 
We cover the same scenarios as the main branch except when an end-user requests a connection 3 ms ahead of the expiration time.
