### PR TITLE
Rename package from quarkus.qe to io.quarkus.qe

### DIFF
--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/GreetingResource.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/GreetingResource.java
@@ -1,4 +1,4 @@
-package quarkus.qe;
+package io.quarkus.qe;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,9 +12,9 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import quarkus.qe.config.AntagonistConfiguration;
-import quarkus.qe.config.ProtagonistConfiguration;
-import quarkus.qe.converter.KrustyEmail;
+import io.quarkus.qe.config.AntagonistConfiguration;
+import io.quarkus.qe.config.ProtagonistConfiguration;
+import io.quarkus.qe.converter.KrustyEmail;
 
 @Path("/hello")
 public class GreetingResource {

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/config/AntagonistConfiguration.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/config/AntagonistConfiguration.java
@@ -1,4 +1,4 @@
-package quarkus.qe.config;
+package io.quarkus.qe.config;
 
 import io.quarkus.arc.config.ConfigProperties;
 

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/config/ProtagonistConfiguration.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/config/ProtagonistConfiguration.java
@@ -1,9 +1,9 @@
-package quarkus.qe.config;
+package io.quarkus.qe.config;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import quarkus.qe.config.interfaces.ProtagonistConfigurable;
+import io.quarkus.qe.config.interfaces.ProtagonistConfigurable;
 
 @Singleton
 public class ProtagonistConfiguration {

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/config/interfaces/IBiography.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/config/interfaces/IBiography.java
@@ -1,4 +1,4 @@
-package quarkus.qe.config.interfaces;
+package io.quarkus.qe.config.interfaces;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/config/interfaces/ProtagonistConfigurable.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/config/interfaces/ProtagonistConfigurable.java
@@ -1,4 +1,4 @@
-package quarkus.qe.config.interfaces;
+package io.quarkus.qe.config.interfaces;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/converter/CustomEmailConverter.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/converter/CustomEmailConverter.java
@@ -1,4 +1,4 @@
-package quarkus.qe.converter;
+package io.quarkus.qe.converter;
 
 import org.eclipse.microprofile.config.spi.Converter;
 

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/converter/KrustyEmail.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/converter/KrustyEmail.java
@@ -1,4 +1,4 @@
-package quarkus.qe.converter;
+package io.quarkus.qe.converter;
 
 public class KrustyEmail {
 

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/providers/CustomConfigSource.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/providers/CustomConfigSource.java
@@ -1,4 +1,4 @@
-package quarkus.qe.providers;
+package io.quarkus.qe.providers;
 
 import java.io.FileNotFoundException;
 import java.io.InputStream;

--- a/022-quarkus-properties-config-all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/022-quarkus-properties-config-all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,1 +1,1 @@
-quarkus.qe.providers.CustomConfigSource
+io.quarkus.qe.providers.CustomConfigSource

--- a/022-quarkus-properties-config-all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/022-quarkus-properties-config-all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -1,1 +1,1 @@
-quarkus.qe.converter.CustomEmailConverter
+io.quarkus.qe.converter.CustomEmailConverter

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/config/VariousConfigurationSourcesTest.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/config/VariousConfigurationSourcesTest.java
@@ -1,4 +1,4 @@
-package quarkus.qe.config;
+package io.quarkus.qe.config;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/config/VariousConfigurationSourcesTestIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/config/VariousConfigurationSourcesTestIT.java
@@ -1,4 +1,4 @@
-package quarkus.qe.config;
+package io.quarkus.qe.config;
 
 import io.quarkus.test.junit.NativeImageTest;
 


### PR DESCRIPTION
The proper package name should be `io.quarkus.qe` as the rest of the modules.