### PR TITLE
Legacy non-application endpoint redirection use case

### DIFF
--- a/020-quarkus-http-non-application-endpoints/src/main/resources/application.properties
+++ b/020-quarkus-http-non-application-endpoints/src/main/resources/application.properties
@@ -2,7 +2,6 @@ quarkus.container-image.name=demo
 quarkus.application.name=non-application endpoints
 quarkus.http.root-path=/api
 quarkus.http.non-application-root-path=/q
-quarkus.http.redirect-to-non-application-root-path=true
 
 quarkus.swagger-ui.always-include=true
 quarkus.health.openapi.included=true

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/CommonNonAppEndpoint.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/CommonNonAppEndpoint.java
@@ -15,7 +15,7 @@ public abstract class CommonNonAppEndpoint {
     protected static final String ROOT_BASE_PATH = "/api/";
     protected static final String QUARKUS_PROFILE = "quarkus.profile";
     protected static final String NATIVE = "native";
-    protected static final boolean IS_NATIVE = System.getProperty(QUARKUS_PROFILE, "").equals(NATIVE);
+    public static final boolean IS_NATIVE = System.getProperty(QUARKUS_PROFILE, "").equals(NATIVE);
     private RequestSpecification request;
     private RequestSpecBuilder spec;
 

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/LegacyNonApplicationEndpointIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/LegacyNonApplicationEndpointIT.java
@@ -1,0 +1,10 @@
+package io.quarkus.qe.non_application.endpoint;
+
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
+
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
+public class LegacyNonApplicationEndpointIT extends LegacyNonApplicationEndpointTest {
+}

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/LegacyNonApplicationEndpointTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/LegacyNonApplicationEndpointTest.java
@@ -1,34 +1,29 @@
 package io.quarkus.qe.non_application.endpoint;
 
-import javax.ws.rs.core.Response;
+import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.IS_NATIVE;
+import static io.restassured.RestAssured.when;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.qe.http.non_application.endpoint.HelloResource;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class RelativePathNonAppEndpointTest extends CommonNonAppEndpoint {
-
-    private static final String BASE_PATH = "q";
+public class LegacyNonApplicationEndpointTest {
 
     @RegisterExtension
-    static final QuarkusProdModeTest relativePathScenario = new QuarkusProdModeTest()
+    static final QuarkusProdModeTest nonApplicationEndpointScenario = new QuarkusProdModeTest()
             .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/api")
-            .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
+            .overrideConfigKey("quarkus.smallrye-health.root-path", "/health")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(HelloResource.class))
             .setRun(true);
 
-    @Override
-    public int getExpectedHttpStatus() {
-        return Response.Status.OK.getStatusCode();
-    }
-
-    @Override
-    public String getBasePath() {
-        return ROOT_BASE_PATH + BASE_PATH;
+    @Test
+    protected void nonAppEndpointScenario() {
+        when().get("/health").then().statusCode(200);
     }
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathTest.java
@@ -17,7 +17,6 @@ public class NonAppEndpointNonRootPathTest extends CommonNonAppEndpoint {
             .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/api")
             .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
-            .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(HelloResource.class))
             .setRun(true);

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTest.java
@@ -18,7 +18,6 @@ public class NonAppEndpointTest extends CommonNonAppEndpoint {
             .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/api")
             .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
-            .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClass(HelloResource.class))
             .setRun(true);

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathTest.java
@@ -18,7 +18,6 @@ public class NonAppEndpointTestNonBaseRootPathTest extends CommonNonAppEndpoint 
             .setBuildNative(IS_NATIVE)
             .overrideConfigKey("quarkus.http.root-path", "/")
             .overrideConfigKey("quarkus.http.non-application-root-path", BASE_PATH)
-            .overrideConfigKey("quarkus.http.redirect-to-non-application-root-path", "false")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(HelloResource.class))
             .setRun(true);


### PR DESCRIPTION
quarkus.http.redirect-to-non-application-root-path deprecated property was removed

This PR removes the deprecated property from test cases and also setup a new scenario where health.root-path is set to "/health" (as used to be in Quarkus 1.7), instead of `/q/health`. This scenario shows up a way to maintain the old endpoint. 


