### PR TITLE
Disable Native tests for module 022  because #quarkus/17653

### DIFF
--- a/022-quarkus-properties-config-all/pom.xml
+++ b/022-quarkus-properties-config-all/pom.xml
@@ -20,6 +20,11 @@
     <profiles>
         <profile>
             <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.additional-build-args>-H:ResourceConfigurationFiles=resources-config.json</quarkus.native.additional-build-args>

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/providers/CustomConfigSource.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/providers/CustomConfigSource.java
@@ -1,6 +1,7 @@
 package io.quarkus.qe.providers;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.Set;
@@ -15,7 +16,7 @@ public class CustomConfigSource implements ConfigSource {
 
     private final Properties customProperties = new Properties();
 
-    public CustomConfigSource() {
+    public CustomConfigSource() throws IOException {
         loadProperties();
     }
 
@@ -39,16 +40,12 @@ public class CustomConfigSource implements ConfigSource {
         return "Custom Config Source";
     }
 
-    public void loadProperties() {
-        try {
-            InputStream in = CustomConfigSource.class.getResourceAsStream(PROPERTIES_FILE);
-            if (in != null) {
-                customProperties.load(in);
-            } else {
-                throw new FileNotFoundException("Property file " + PROPERTIES_FILE + " not found in the classpath");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
+    public void loadProperties() throws IOException {
+        InputStream in = CustomConfigSource.class.getResourceAsStream(PROPERTIES_FILE);
+        if (in != null) {
+            customProperties.load(in);
+        } else {
+            throw new FileNotFoundException("Property file " + PROPERTIES_FILE + " not found in the classpath");
         }
     }
 }

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeBulkOfPropertiesIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeBulkOfPropertiesIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.bulk;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled("TODO: Can't add configsource.properties because of https://github.com/quarkusio/quarkus/issues/17653")
 @NativeImageTest
 public class NativeBulkOfPropertiesIT extends BulkOfPropertiesTest {
 

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeConfigValueIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeConfigValueIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.bulk;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled("TODO: Can't add configsource.properties because of https://github.com/quarkusio/quarkus/issues/17653")
 @NativeImageTest
 public class NativeConfigValueIT extends ConfigValueTest {
 

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/config/VariousConfigurationSourcesTestIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/config/VariousConfigurationSourcesTestIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.config;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled("TODO: Can't add configsource.properties because of https://github.com/quarkusio/quarkus/issues/17653")
 @NativeImageTest
 public class VariousConfigurationSourcesTestIT extends VariousConfigurationSourcesTest {
 

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/NativeConfigMappingResourceIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/NativeConfigMappingResourceIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.configmapping;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled("TODO: Can't add configsource.properties because of https://github.com/quarkusio/quarkus/issues/17653")
 @NativeImageTest
 public class NativeConfigMappingResourceIT extends ConfigMappingResourceTest {
 }


### PR DESCRIPTION
Adding external properties on Native make the app fail to start. Reported by https://github.com/quarkusio/quarkus/issues/17653