### PR TITLE
Fix 009 module to use @Identifier instead of @Named to inject broker

### DIFF
--- a/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/providers/KafkaProviders.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/main/java/io/quarkus/qe/providers/KafkaProviders.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -16,11 +15,13 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
+import io.smallrye.common.annotation.Identifier;
+
 @ApplicationScoped
 public class KafkaProviders {
 
     @Inject
-    @Named("default-kafka-broker")
+    @Identifier("default-kafka-broker")
     Map<String, Object> config;
 
     @Produces


### PR DESCRIPTION
This change is related to https://github.com/quarkusio/quarkus/commit/11bc00f324b6ed4166ab4250e6661060b7d1a4d4.
The problem is that keeping injecting the default Kafka broker using `@Named` is now failing:

```java
@ApplicationScoped
public class KafkaProviders {

    @Inject
    @Named("default-kafka-broker")
    Map<String, Object> config;
}
```

Using:

```java
@ApplicationScoped
public class KafkaProviders {

    @Inject
    @Identifier("default-kafka-broker")
    Map<String, Object> config;
}
```

It works. 

Therefore, this is a breaking change that should be noted in the Migration guide for 2.x. Reported by https://github.com/quarkusio/quarkus/issues/17754