### PR TITLE
Use Quarkus Camel version 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <testcontainers.version>1.15.2</testcontainers.version>
     <strimzi.testcontainers.version>0.22.1</strimzi.testcontainers.version>
     <wiremock.version>2.27.2</wiremock.version>
-    <version.quarkus.camel>1.8.1</version.quarkus.camel>
+    <version.quarkus.camel>1.6.0</version.quarkus.camel>
     <apicurio-registry-utils-serde.version>1.2.2.Final</apicurio-registry-utils-serde.version>
     <confluent.kafka-avro-serializer.version>6.0.0</confluent.kafka-avro-serializer.version>
 


### PR DESCRIPTION
Quarkus 1.11.7.Final on platform was aligned with Camel Quarkus 1.6.0, which was aligned with Camel 3.7.0.