### PR TITLE
Disable StrimziKafkaIT test on Native because of #quarkus/issues/17829

### DIFF
--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/StrimziKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/StrimziKafkaIT.java
@@ -1,10 +1,13 @@
 package io.quarkus.qe.kafka;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.qe.kafka.resources.JaegerTestResource;
 import io.quarkus.qe.kafka.resources.StrimziKafkaResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled(value = "Kafka failing when using Apicurio registry on Native: https://github.com/quarkusio/quarkus/issues/17829")
 @NativeImageTest
 @QuarkusTestResource(StrimziKafkaResource.class)
 @QuarkusTestResource(JaegerTestResource.class)


### PR DESCRIPTION
Kafka failing when using Apicurio registry on Native: https://github.com/quarkusio/quarkus/issues/17829