### PR TITLE
Disable AnnotationScheduledJobsQuartz and LegacyNonApplication on Native

### DIFF
--- a/017-quartz-cluster/src/test/java/io/quarkus/qe/quartz/NativeAnnotationScheduledJobsQuartzIT.java
+++ b/017-quartz-cluster/src/test/java/io/quarkus/qe/quartz/NativeAnnotationScheduledJobsQuartzIT.java
@@ -3,8 +3,10 @@ package io.quarkus.qe.quartz;
 import static io.quarkus.qe.quartz.resources.ApplicationResource.NATIVE;
 import static io.quarkus.qe.quartz.resources.ApplicationResource.QUARKUS_PROFILE;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@Disabled(value = "Due to high native build execution time for the three Quarkus services")
 @EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class NativeAnnotationScheduledJobsQuartzIT extends AnnotationScheduledJobsQuartzTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/LegacyNonApplicationEndpointIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/LegacyNonApplicationEndpointIT.java
@@ -3,8 +3,10 @@ package io.quarkus.qe.non_application.endpoint;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@Disabled(value = "Due to high native build execution time for the three Quarkus services")
 @EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class LegacyNonApplicationEndpointIT extends LegacyNonApplicationEndpointTest {
 }


### PR DESCRIPTION
These two scenarios are taking more than 1 hour:

```
Time elapsed: 1,088.937 s - in io.quarkus.qe.quartz.NativeAnnotationScheduledJobsQuartzIT
Time elapsed: 1,273.42 s - in io.quarkus.qe.non_application.endpoint.LegacyNonApplicationEndpointIT
```