### PR TITLE
Fix properties module by removing the Person field

### DIFF
--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/ConfigMappingResource.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/ConfigMappingResource.java
@@ -10,37 +10,22 @@ import io.smallrye.config.ConfigMapping;
 @Path("/config-mapping")
 public class ConfigMappingResource {
     @Inject
-    Person personField;
-
-    @Inject
     @ConfigMapping(prefix = "overrides.person")
-    Person personOverridesField;
+    PersonInterface personOverridesInterface;
 
     @Inject
     PersonInterface personInterface;
 
     @GET
-    @Path("/person/name/from-field")
-    public String getPersonNameFromField() {
-        return personField.name;
+    @Path("/person/name/from-overrides-interface")
+    public String getPersonNameFromOverridesInterface() {
+        return personOverridesInterface.name();
     }
 
     @GET
-    @Path("/person/age/from-field")
-    public int getPersonAgeFromField() {
-        return personField.age;
-    }
-
-    @GET
-    @Path("/person/name/from-overrides-field")
-    public String getPersonNameFromOverridesField() {
-        return personOverridesField.name;
-    }
-
-    @GET
-    @Path("/person/age/from-overrides-field")
-    public int getPersonAgeFromOverridesField() {
-        return personOverridesField.age;
+    @Path("/person/age/from-overrides-interface")
+    public int getPersonAgeFromOverridesInterface() {
+        return personOverridesInterface.age();
     }
 
     @GET

--- a/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/Person.java
+++ b/022-quarkus-properties-config-all/src/main/java/io/quarkus/qe/configmapping/Person.java
@@ -1,9 +1,0 @@
-package io.quarkus.qe.configmapping;
-
-import io.smallrye.config.ConfigMapping;
-
-@ConfigMapping(prefix = "person")
-public class Person {
-    String name;
-    int age;
-}

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/ConfigMappingResourceTest.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/ConfigMappingResourceTest.java
@@ -19,15 +19,9 @@ public class ConfigMappingResourceTest {
     private static final int EXPECTED_OVERRIDES_PERSON_AGE = 23;
 
     @Test
-    public void shouldInjectFieldWithConfigMapping() {
-        assertResponseIs("/person/name/from-field", EXPECTED_PERSON_NAME);
-        assertResponseIs("/person/age/from-field", EXPECTED_PERSON_AGE);
-    }
-
-    @Test
-    public void shouldInjectFieldUsingOverriddenConfigWithConfigMapping() {
-        assertResponseIs("/person/name/from-overrides-field", EXPECTED_OVERRIDES_PERSON_NAME);
-        assertResponseIs("/person/age/from-overrides-field", EXPECTED_OVERRIDES_PERSON_AGE);
+    public void shouldInjectInterfaceUsingOverriddenConfigWithConfigMapping() {
+        assertResponseIs("/person/name/from-overrides-interface", EXPECTED_OVERRIDES_PERSON_NAME);
+        assertResponseIs("/person/age/from-overrides-interface", EXPECTED_OVERRIDES_PERSON_AGE);
     }
 
     @Test


### PR DESCRIPTION
Quarkus upstream upgraded SmallRye Config to 2.4.3 and it seems that there is no longer possible to use the annotation @ConfigMapping on classes, only in interfaces.
As we're already covering the interface mapping, I removed the field coverage.
Related issue: quarkusio/quarkus#19298