### PR TITLE
Disable non application tests on Native due to high execution time

### DIFF
--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointIT.java
@@ -3,8 +3,10 @@ package io.quarkus.qe.non_application.endpoint;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@Disabled(value = "Due to high execution time to build app on Native")
 @EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class NonAppEndpointIT extends NonAppEndpointTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointNonRootPathIT.java
@@ -3,8 +3,10 @@ package io.quarkus.qe.non_application.endpoint;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@Disabled(value = "Due to high execution time to build app on Native")
 @EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class NonAppEndpointNonRootPathIT extends NonAppEndpointNonRootPathTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/NonAppEndpointTestNonBaseRootPathIT.java
@@ -3,8 +3,10 @@ package io.quarkus.qe.non_application.endpoint;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@Disabled(value = "Due to high execution time to build app on Native")
 @EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class NonAppEndpointTestNonBaseRootPathIT extends NonAppEndpointTestNonBaseRootPathTest {
 }

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/RelativePathNonAppEndpointIT.java
@@ -3,8 +3,10 @@ package io.quarkus.qe.non_application.endpoint;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.NATIVE;
 import static io.quarkus.qe.non_application.endpoint.CommonNonAppEndpoint.QUARKUS_PROFILE;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
+@Disabled(value = "Due to high execution time to build app on Native")
 @EnabledIfSystemProperty(named = QUARKUS_PROFILE, matches = NATIVE)
 public class RelativePathNonAppEndpointIT extends RelativePathNonAppEndpointTest {
 }


### PR DESCRIPTION
These tests require to build the app on Native (it's not reusing the native artifact from the target folder).
This coverage is now in the test suite, so it should be fine to disable these tests.

Execution times:
```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,247.033 s - in io.quarkus.qe.non_application.endpoint.NonAppEndpointIT
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 287.141 s - in io.quarkus.qe.non_application.endpoint.RelativePathNonAppEndpointIT
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,236.566 s - in io.quarkus.qe.non_application.endpoint.NonAppEndpointNonRootPathIT
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 284.907 s - in io.quarkus.qe.non_application.endpoint.NonAppEndpointTestNonBaseRootPathIT
```