### PR TITLE
Separate @QuarkusTest execution

### DIFF
--- a/012-quarkus-kafka-streams/src/test/java/io/quarkus/qe/SslAlertMonitorTest.java
+++ b/012-quarkus-kafka-streams/src/test/java/io/quarkus/qe/SslAlertMonitorTest.java
@@ -1,10 +1,15 @@
 package io.quarkus.qe;
 
+import org.junit.jupiter.api.Tag;
+
 import io.quarkus.qe.resources.SslStrimziKafkaTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(SslStrimziKafkaTestResource.class)
+// remove this once https://github.com/quarkusio/quarkus/pull/19477
+// has been included in all versions you want to support
+@Tag("io.quarkus.test.junit.QuarkusTest")
 public class SslAlertMonitorTest extends BaseAlertMonitorTest {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,26 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludedGroups>io.quarkus.test.junit.QuarkusTest</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>quarkus-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <groups>io.quarkus.test.junit.QuarkusTest</groups>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <systemProperties>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>


### PR DESCRIPTION
At some point, maybe this should be put in a shared constant but it
seems a bit too involved to create a shared module just for that.