### PR TITLE
Bump testcontainers to 1.16.0 ++ set exposed ports for 009 and 010

### DIFF
--- a/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/InfinispanTestResource.java
+++ b/009-quarkus-infinispan-grpc-kafka/src/test/java/io/quarkus/qe/containers/InfinispanTestResource.java
@@ -17,7 +17,6 @@ public class InfinispanTestResource implements QuarkusTestResourceLifecycleManag
 
     private GenericContainer<?> infinispan;
 
-    @SuppressWarnings("resource")
     @Override
     public Map<String, String> start() {
 
@@ -31,7 +30,8 @@ public class InfinispanTestResource implements QuarkusTestResourceLifecycleManag
                 .withClasspathResourceMapping("server.jks",
                         "/user-config/server.jks", BindMode.READ_ONLY)
                 .withEnv("CONFIG_PATH", "/user-config/config.yaml")
-                .withEnv("IDENTITIES_PATH", "/user-config/identities.yaml");
+                .withEnv("IDENTITIES_PATH", "/user-config/identities.yaml")
+                .withExposedPorts(INFINISPAN_PORT);
 
         infinispan.start();
         final String hosts = infinispan.getContainerIpAddress() + ":" + infinispan.getMappedPort(INFINISPAN_PORT);

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/containers/JaegerTestResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/containers/JaegerTestResource.java
@@ -27,7 +27,8 @@ public class JaegerTestResource implements QuarkusTestResourceLifecycleManager {
 
         container = new GenericContainer<>("jaegertracing/all-in-one:latest")
                 .waitingFor(
-                        new LogMessageWaitStrategy().withRegEx(".*\"Health Check state change\",\"status\":\"ready\".*\\s"));
+                        new LogMessageWaitStrategy().withRegEx(".*\"Health Check state change\",\"status\":\"ready\".*\\s"))
+                .withExposedPorts(TRACE_PORT, REST_PORT);
         container.start();
 
         return Collections.singletonMap(QUARKUS_JAEGER_PROPERTY, traceEndpoint());

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
-        <testcontainers.version>1.15.2</testcontainers.version>
+        <testcontainers.version>1.16.0</testcontainers.version>
         <strimzi.testcontainers.version>0.22.1</strimzi.testcontainers.version>
         <wiremock.version>2.27.2</wiremock.version>
         <apicurio-registry-utils-serde.version>1.3.2.Final</apicurio-registry-utils-serde.version>


### PR DESCRIPTION
The modules 009 and 010 were failing because Quarkus upstream upgraded testcontainers to 1.16 and we were not marking as exposed some necessary ports in the containers for modules 009 and 010.