### PR TITLE
Remove unnecessary quarkus-vertx-web dependency

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -232,7 +232,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/300-quarkus-vertx-webClient/pom.xml
+++ b/300-quarkus-vertx-webClient/pom.xml
@@ -18,11 +18,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx</artifactId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/302-quarkus-vertx-jwt/pom.xml
+++ b/302-quarkus-vertx-jwt/pom.xml
@@ -14,7 +14,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/config/AuthNConfig.java
+++ b/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/config/AuthNConfig.java
@@ -9,7 +9,7 @@ public interface AuthNConfig {
 
     String secret();
 
-    @WithName("tokenLiveSpanMin")
+    @WithName("token-live-span-min")
     int liveSpan();
 
     @WithName("jwt.claims")

--- a/303-quarkus-vertx-sql/pom.xml
+++ b/303-quarkus-vertx-sql/pom.xml
@@ -10,7 +10,11 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/304-quarkus-vertx-routes/pom.xml
+++ b/304-quarkus-vertx-routes/pom.xml
@@ -10,7 +10,11 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-vertx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Issue Ref: 

https://github.com/quarkusio/quarkus/pull/19933
https://github.com/quarkusio/quarkus/pull/20058

- Rename quarkus-vertx-web to quarkus-reactive-routes extensions
- merge the quarkus-vertx and quarkus-vertx-core extentions