### PR TITLE
Remove `quarkus-hibernate-orm-rest-data-panache` due to a dependency conflict

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -232,10 +232,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>
@@ -475,10 +471,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm-panache-kotlin</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
-        </dependency>
+        <!--        Caused by: java.lang.IllegalStateException:  Multiple matching properties for name "security.jaxrs.deny-unannotated-endpoints" -->
+        <!--        <dependency>-->
+        <!--            <groupId>io.quarkus</groupId>-->
+        <!--            <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>-->
+        <!--        </dependency>-->
         <!--        Caused by: java.lang.IllegalStateException: Booting an Hibernate Reactive serviceregistry on a non-reactive RecordedState!-->
         <!--        <dependency>-->
         <!--            <groupId>io.quarkus</groupId>-->

--- a/002-quarkus-all-extensions/src/main/resources/application.properties
+++ b/002-quarkus-all-extensions/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # Configuration file
 # key = value
+quarkus.devservices.enabled=false
 
 # Flyway minimal config properties
 quarkus.flyway.migrate-at-start=false


### PR DESCRIPTION
 - `quarkus-hibernate-orm-rest-data-panache` brings reactive libraries as `quarkus-resteasy-reactive` that has a conflict with other non-reactive libraries that are in the module `002-quarkus-all-extensions`

- Remove Dependency: `io.quarkus:quarkus-vertx` was duplicated