### PR TITLE
Revert changes related to hibernate-orm-rest-data-panache and spring web

### DIFF
--- a/011-quarkus-panache-rest-flyway/pom.xml
+++ b/011-quarkus-panache-rest-flyway/pom.xml
@@ -14,7 +14,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/014-quarkus-panache-with-transactions-xa/pom.xml
+++ b/014-quarkus-panache-with-transactions-xa/pom.xml
@@ -14,7 +14,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/017-quartz-cluster/pom.xml
+++ b/017-quartz-cluster/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/602-spring-data-rest/pom.xml
+++ b/602-spring-data-rest/pom.xml
@@ -14,7 +14,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/603-spring-web-smallrye-openapi/pom.xml
+++ b/603-spring-web-smallrye-openapi/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-qute</artifactId>
+            <artifactId>quarkus-resteasy-qute</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
The quarkus-hibernate-orm-rest-data-panache and spring web extensions are no longer reactive. This has been reverted in Quarkus main: https://github.com/quarkusio/quarkus/commit/5054ba11db07d7d2a538a989d707ae90bf6ddd36