### PR TITLE
Upgrade ubi images to 21.2-java11

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.1-java11", "ubi-quarkus-mandrel:21.1-java11" ]
+        image: [ "ubi-quarkus-native-image:21.2-java11", "ubi-quarkus-mandrel:21.2-java11" ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -172,7 +172,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "21.0.0.java11"]
+        graalvm-version: ["21.2.0.java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.1-java11"]
+        image: [ "ubi-quarkus-native-image:21.2-java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -140,7 +140,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "21.0.0.java11"]
+        graalvm-version: ["21.2.0.java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
Fix [daily](https://github.com/quarkus-qe/beefy-scenarios/runs/3858733676?check_suite_focus=true) build. 
Quarkus upstream has been updated to `ubi-quarkus-mandrel:21.2-java11`
