### PR TITLE
Change MySQL 5.7 and PostgreSQL 9.6 due to flyway upgrade

### DIFF
--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/MysqlResource.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/MysqlResource.java
@@ -16,7 +16,7 @@ public class MysqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        mysqlContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/mysql:5.7.32"))
+        mysqlContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/mysql:8.0"))
                 .withEnv("MYSQL_ROOT_PASSWORD", "test")
                 .withEnv("MYSQL_USER", "test")
                 .withEnv("MYSQL_PASSWORD", "test")
@@ -24,7 +24,7 @@ public class MysqlResource implements QuarkusTestResourceLifecycleManager {
                 .withExposedPorts(3306);
 
         mysqlContainer.waitingFor(new HostPortWaitStrategy()).waitingFor(
-                Wait.forLogMessage(".*MySQL Community Server.*", 1)).start();
+                Wait.forLogMessage(".*ready for connections.*", 1)).start();
 
         Map<String, String> config = new HashMap<>();
         config.put("quarkus.datasource.mysql.jdbc.url",

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/PostgresqlResource.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/PostgresqlResource.java
@@ -15,7 +15,7 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/debezium/postgres:latest"))
+        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/postgresql:13.4.0"))
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_DB", "amadeus")


### PR DESCRIPTION
Quarkus upgraded Flyway to 8.0 in https://github.com/quarkusio/quarkus/pull/20760 and Flyway 8.0 does not support MySQL anylonger:

```
Caused by: org.flywaydb.core.internal.license.FlywayEditionUpgradeRequiredException: Flyway Teams Edition or MySQL upgrade required: MySQL 5.7 is no longer supported by Flyway Community Edition, but still supported by Flyway Teams Edition.
```

PostgreSQL 9.6 is also unsupported:

```
Caused by: org.flywaydb.core.internal.license.FlywayEditionUpgradeRequiredException: Flyway Teams Edition or PostgreSQL upgrade required: PostgreSQL 9.6 is no longer supported by Flyway Community Edition, but still supported by Flyway Teams Edition.
```