### PR TITLE
Add quarkus-resteasy-jackson dependency for 603-spring-web module

### DIFF
--- a/603-spring-web-smallrye-openapi/pom.xml
+++ b/603-spring-web-smallrye-openapi/pom.xml
@@ -18,6 +18,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Additional dep is needed because of decoupling of RestEasy module from quarkus-spring-web