### PR TITLE
Add `quarkus-jackson` alongside `quarkus-vertx`

### DIFF
--- a/302-quarkus-vertx-jwt/pom.xml
+++ b/302-quarkus-vertx-jwt/pom.xml
@@ -18,6 +18,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-redis-client</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
As a result of https://github.com/quarkusio/quarkus/pull/21142,
`io.quarkus:quarkus-jackson` has to be added manually alongside
`io.quarkus:quarkus-vertx` if we want to use
`com.fasterxml.jackson.databind` classes.
In case of `302-quarkus-vertx-jwt`, the
`VertxAuthObjectMapperCustomizer` requires this dependency.