### PR TITLE
Comment `303-quarkus-vertx-sql` and `304-quarkus-vertx-routes` due to an issue on hibernate validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,9 @@
         <module>300-quarkus-vertx-webClient</module>
         <module>301-quarkus-vertx-kafka</module>
         <module>302-quarkus-vertx-jwt</module>
-        <module>303-quarkus-vertx-sql</module>
-        <module>304-quarkus-vertx-routes</module>
+        <!-- TODO: https://github.com/quarkusio/quarkus/issues/21516 -->
+        <!--<module>303-quarkus-vertx-sql</module>
+        <module>304-quarkus-vertx-routes</module> -->
         <module>601-spring-data-primitive-types</module>
         <module>602-spring-data-rest</module>
         <module>603-spring-web-smallrye-openapi</module>


### PR DESCRIPTION
Native compilation error:

```
`Caused by: java.lang.NoClassDefFoundError: javax/ws/rs/ext/ExceptionMapper`
```

- disable modules `303-quarkus-vertx-sql` and `304-quarkus-vertx-routes` because of this native build image issue: https://github.com/quarkusio/quarkus/issues/21516 