### PR TITLE
Disable native build in `300-quarkus-vertx-webClient` and `301-quarkus-vertx-kafka` modules

### DIFF
--- a/300-quarkus-vertx-webClient/pom.xml
+++ b/300-quarkus-vertx-webClient/pom.xml
@@ -50,6 +50,20 @@
         </dependency>
     </dependencies>
     <profiles>
+        <profile>
+            <!-- TODO: https://github.com/quarkusio/quarkus/issues/22275 -->
+            <!-- Disable native build on this module -->
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- To not build the module on Native -->
+                <quarkus.package.type>fast-jar</quarkus.package.type>
+            </properties>
+        </profile>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>
             <id>skip-tests-on-windows</id>

--- a/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
+++ b/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
@@ -5,10 +5,12 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.nio.file.Paths;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/22275")
 @NativeImageTest
 public class ChuckNorrisResourceIT extends ChuckNorrisResourceTest {
 

--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -78,6 +78,20 @@
         </dependency>
     </dependencies>
     <profiles>
+        <profile>
+            <!-- TODO: https://github.com/quarkusio/quarkus/issues/22275 -->
+            <!-- Disable native build on this module -->
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- To not build the module on Native -->
+                <quarkus.package.type>fast-jar</quarkus.package.type>
+            </properties>
+        </profile>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>
             <id>skip-tests-on-windows</id>

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeConfluentKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeConfluentKafkaIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.kafka;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/22275")
 @NativeImageTest
 public class NativeConfluentKafkaIT extends ConfluentKafkaTest {
 

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeStrimziKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeStrimziKafkaIT.java
@@ -1,7 +1,10 @@
 package io.quarkus.qe.kafka;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled("https://github.com/quarkusio/quarkus/issues/22275")
 @NativeImageTest
 public class NativeStrimziKafkaIT extends StrimziKafkaTest {
 


### PR DESCRIPTION
Workaround to https://github.com/quarkusio/quarkus/issues/22275.