### PR TITLE
Revert "Disable native build in `300-quarkus-vertx-webClient` and `301-quarkus-vertx-kafka` modules"

### DIFF
--- a/300-quarkus-vertx-webClient/pom.xml
+++ b/300-quarkus-vertx-webClient/pom.xml
@@ -50,20 +50,6 @@
         </dependency>
     </dependencies>
     <profiles>
-        <profile>
-            <!-- TODO: https://github.com/quarkusio/quarkus/issues/22275 -->
-            <!-- Disable native build on this module -->
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <!-- To not build the module on Native -->
-                <quarkus.package.type>fast-jar</quarkus.package.type>
-            </properties>
-        </profile>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>
             <id>skip-tests-on-windows</id>

--- a/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
+++ b/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
@@ -5,12 +5,10 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.NativeImageTest;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/22275")
 @NativeImageTest
 public class ChuckNorrisResourceIT extends ChuckNorrisResourceTest {
 

--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -78,20 +78,6 @@
         </dependency>
     </dependencies>
     <profiles>
-        <profile>
-            <!-- TODO: https://github.com/quarkusio/quarkus/issues/22275 -->
-            <!-- Disable native build on this module -->
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <!-- To not build the module on Native -->
-                <quarkus.package.type>fast-jar</quarkus.package.type>
-            </properties>
-        </profile>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->
         <profile>
             <id>skip-tests-on-windows</id>

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeConfluentKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeConfluentKafkaIT.java
@@ -1,10 +1,7 @@
 package io.quarkus.qe.kafka;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.NativeImageTest;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/22275")
 @NativeImageTest
 public class NativeConfluentKafkaIT extends ConfluentKafkaTest {
 

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeStrimziKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeStrimziKafkaIT.java
@@ -1,10 +1,7 @@
 package io.quarkus.qe.kafka;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.NativeImageTest;
 
-@Disabled("https://github.com/quarkusio/quarkus/issues/22275")
 @NativeImageTest
 public class NativeStrimziKafkaIT extends StrimziKafkaTest {
 


### PR DESCRIPTION
Revert "Disable native build in `300-quarkus-vertx-webClient` and `301-quarkus-vertx-kafka` modules"

This reverts commit 58fe6a7e0a2dd2ff4439710c3abc640e719a9b4b.

Issue is fixed in Quarkus 2.6.1.Final