### PR TITLE
Use custom marker annotation instead of @ConfigProperty

### DIFF
--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
@@ -9,9 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpStatus;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.qe.containers.JaegerApiEndpointAddress;
 import io.quarkus.qe.containers.JaegerTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 
@@ -24,7 +24,7 @@ public abstract class AbstractPingPongResourceTest {
     private static final String PING_RESOURCE = "PingResource";
     private static final String PONG_RESOURCE = "PongResource";
 
-    @ConfigProperty(name = JaegerTestResource.JAEGER_API_ENDPOINT, defaultValue = "http://localhost:16686/api/traces")
+    @JaegerApiEndpointAddress
     String jaegerEndpoint;
 
     @Test

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/containers/JaegerApiEndpointAddress.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/containers/JaegerApiEndpointAddress.java
@@ -1,0 +1,8 @@
+package io.quarkus.qe.containers;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JaegerApiEndpointAddress {
+}

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/containers/JaegerTestResource.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/containers/JaegerTestResource.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
@@ -44,8 +43,8 @@ public class JaegerTestResource implements QuarkusTestResourceLifecycleManager {
         Class<?> c = testInstance.getClass();
         while (c != Object.class) {
             for (Field f : c.getDeclaredFields()) {
-                ConfigProperty configProperty = f.getAnnotation(ConfigProperty.class);
-                if (configProperty != null && JAEGER_API_ENDPOINT.equals(configProperty.name())) {
+                JaegerApiEndpointAddress jaegerEndpoint = f.getAnnotation(JaegerApiEndpointAddress.class);
+                if (jaegerEndpoint != null) {
                     setFieldValue(f, testInstance, apiEndpoint());
                 }
             }


### PR DESCRIPTION
Use custom marker annotation instead of @ConfigProperty

https://github.com/quarkusio/quarkus/pull/24579 - @ConfigProperty is not intended for integration tests