### PR TITLE
Migrate Bitnami images to the official ones

### DIFF
--- a/002-quarkus-all-extensions/src/test/java/io/quarkus/qe/core/containers/MongoTestResource.java
+++ b/002-quarkus-all-extensions/src/test/java/io/quarkus/qe/core/containers/MongoTestResource.java
@@ -19,7 +19,7 @@ public class MongoTestResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        resource = new GenericContainer<>("quay.io/bitnami/mongodb:4.0.23");
+        resource = new GenericContainer<>("docker.io/mongo:4.0.23");
         resource.waitingFor(new LogMessageWaitStrategy().withRegEx("(?i).*waiting for connections.*"));
         resource.addExposedPort(PORT);
         resource.start();

--- a/013-quarkus-oidc-restclient/src/main/resources/application.properties
+++ b/013-quarkus-oidc-restclient/src/main/resources/application.properties
@@ -42,3 +42,5 @@ io.quarkus.qe.ping.clients.TokenPropagationPongClient/mp-rest/url=http://localho
 
 #OpenAPI
 quarkus.smallrye-openapi.store-schema-directory=target/generated/jax-rs/
+quarkus.smallrye-openapi.info-title=Custom API Title
+quarkus.smallrye-openapi.info-version=1.0.1

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/OpenApiTest.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/OpenApiTest.java
@@ -37,7 +37,7 @@ public class OpenApiTest {
     private static final Path JSON_FILE_NAME_FULL_PATH = Paths.get(directory + JSON_FILE_NAME);
 
     private static final String EXPECTED_TAGS = "[{\"name\":\"Ping\",\"description\":\"Ping API\"},{\"name\":\"Pong\",\"description\":\"Pong API\"}]";
-    private static final String EXPECTED_INFO = "{\"title\":\"Generated API\",\"version\":\"1.0\"}";
+    private static final String EXPECTED_INFO = "{\"title\":\"Custom API Title\",\"version\":\"1.0.1\"}";
 
     // QUARKUS-716
     @Test

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/OpenApiTestIT.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/OpenApiTestIT.java
@@ -4,13 +4,5 @@ import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
 public class OpenApiTestIT extends OpenApiTest {
-    // quarkus-maven-plugin:build adjusts OpenAPI info
-    // see https://github.com/quarkusio/quarkus/pull/19148/commits/8fe04d7a06aa976e0b85d72864578f3ab834a27a
-    // surefire is executed before quarkus-maven-plugin:build and thus the message there is the generic one
-    private static final String QUARKUS_ADJUSTED_INFO = "{\"title\":\"013-quarkus-oidc-restclient API\",\"version\":\"1.0.0-SNAPSHOT\"}";
 
-    @Override
-    String getExpectedInfo() {
-        return QUARKUS_ADJUSTED_INFO;
-    }
 }

--- a/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/containers/MySqlDatabaseTestResource.java
+++ b/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/containers/MySqlDatabaseTestResource.java
@@ -26,7 +26,7 @@ public class MySqlDatabaseTestResource implements QuarkusTestResourceLifecycleMa
     @Override
     public Map<String, String> start() {
         container = new MySQLContainer<>(
-                DockerImageName.parse("quay.io/bitnami/mysql:5.7.32").asCompatibleSubstituteFor(MYSQL));
+                DockerImageName.parse("docker.io/mysql:5.7").asCompatibleSubstituteFor(MYSQL));
         container.withUrlParam("currentSchema", DEFAULT_SCHEMA);
         container.start();
 

--- a/019-quarkus-consul/src/test/java/io/quarkus/qe/containers/ConsulContainer.java
+++ b/019-quarkus-consul/src/test/java/io/quarkus/qe/containers/ConsulContainer.java
@@ -9,7 +9,7 @@ public class ConsulContainer extends GenericContainer<ConsulContainer> {
     private static final int PORT = 8500;
 
     public ConsulContainer() {
-        super("quay.io/bitnami/consul:1.9.3");
+        super("docker.io/consul:1.9.3");
         waitingFor(new LogMessageWaitStrategy().withRegEx(".*Synced node info.*\\s"));
         withStartupTimeout(Duration.ofMillis(60000));
         addFixedExposedPort(PORT, PORT);

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/resources/RedisResource.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/resources/RedisResource.java
@@ -16,7 +16,7 @@ public class RedisResource implements QuarkusTestResourceLifecycleManager {
     @Override
     public Map<String, String> start() {
 
-        redisContainer = new GenericContainer(DockerImageName.parse("quay.io/bitnami/redis:6.0"))
+        redisContainer = new GenericContainer(DockerImageName.parse("docker.io/redis:6.0"))
                 .withEnv("ALLOW_EMPTY_PASSWORD", "yes").withExposedPorts(6379);
         redisContainer.start();
 

--- a/303-quarkus-vertx-sql/pom.xml
+++ b/303-quarkus-vertx-sql/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
     </dependencies>
     <profiles>
         <!-- Skipped on Windows as does not support Linux Containers / Testcontainers -->

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/MysqlResource.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/MysqlResource.java
@@ -16,7 +16,7 @@ public class MysqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        mysqlContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/mysql:8.0"))
+        mysqlContainer = new GenericContainer<>(DockerImageName.parse("docker.io/mysql:8.0"))
                 .withEnv("MYSQL_ROOT_PASSWORD", "test")
                 .withEnv("MYSQL_USER", "test")
                 .withEnv("MYSQL_PASSWORD", "test")

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/MysqlResource.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/MysqlResource.java
@@ -24,7 +24,7 @@ public class MysqlResource implements QuarkusTestResourceLifecycleManager {
                 .withExposedPorts(3306);
 
         mysqlContainer.waitingFor(new HostPortWaitStrategy()).waitingFor(
-                Wait.forLogMessage(".*ready for connections.*", 1)).start();
+                Wait.forLogMessage(".*ready for connections.*port: 33060.*", 1)).start();
 
         Map<String, String> config = new HashMap<>();
         config.put("quarkus.datasource.mysql.jdbc.url",

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/PostgresqlResource.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/test/resources/PostgresqlResource.java
@@ -17,7 +17,7 @@ public class PostgresqlResource implements QuarkusTestResourceLifecycleManager {
 
     @Override
     public Map<String, String> start() {
-        postgresContainer = new GenericContainer<>(DockerImageName.parse("quay.io/bitnami/postgresql:13.4.0"))
+        postgresContainer = new GenericContainer<>(DockerImageName.parse("docker.io/postgres:13.6"))
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_DB", "amadeus")

--- a/303-quarkus-vertx-sql/src/test/resources/docker-compose.yaml
+++ b/303-quarkus-vertx-sql/src/test/resources/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       POSTGRES_DB: amadeus
 
   mysql:
-    image: docker.io/mysql:5.7
+    image: docker.io/mysql:5.7.32
     hostname: mysql
     container_name: mysql
     ports:

--- a/303-quarkus-vertx-sql/src/test/resources/docker-compose.yaml
+++ b/303-quarkus-vertx-sql/src/test/resources/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       POSTGRES_DB: amadeus
 
   mysql:
-    image: quay.io/bitnami/mysql:5.7.32
+    image: docker.io/mysql:5.7
     hostname: mysql
     container_name: mysql
     ports:

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnRequestBodyRouteHandlerTest.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnRequestBodyRouteHandlerTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.qe.validation;
 
-import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorDetails;
+import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorDetail;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorField;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorStatus;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorTitle;
@@ -30,7 +30,7 @@ public class ValidationOnRequestBodyRouteHandlerTest {
                 .extract().as(ValidationErrorResponse.class);
 
         assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
+        assertValidationErrorDetail(response);
         assertValidationErrorStatus(response, HttpStatus.SC_BAD_REQUEST);
         assertValidationErrorField(response, "validateRequestBody.param.firstCode", "First code must have 3 characters");
     }
@@ -49,7 +49,7 @@ public class ValidationOnRequestBodyRouteHandlerTest {
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .extract().as(ValidationErrorResponse.class);
         assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
+        assertValidationErrorDetail(response);
         assertValidationErrorStatus(response, HttpStatus.SC_BAD_REQUEST);
         assertValidationErrorField(response, "validateRequestBody.param.firstCode", "First code must have 3 characters");
         assertValidationErrorField(response, "validateRequestBody.param.secondCode", "Second second must match pattern");
@@ -71,7 +71,7 @@ public class ValidationOnRequestBodyRouteHandlerTest {
                 .extract().as(ValidationErrorResponse.class);
 
         assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
+        assertValidationErrorDetail(response);
         assertValidationErrorStatus(response, HttpStatus.SC_BAD_REQUEST);
         assertValidationErrorField(response, "validateRequestBody.param.custom", "Value must be uppercase");
     }

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnRequestParamRouteHandlerTest.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnRequestParamRouteHandlerTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.qe.validation;
 
-import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorDetails;
+import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorDetail;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorField;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorStatus;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorTitle;
@@ -25,7 +25,7 @@ public class ValidationOnRequestParamRouteHandlerTest {
                 .extract().as(ValidationErrorResponse.class);
 
         assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
+        assertValidationErrorDetail(response);
         assertValidationErrorStatus(response, HttpStatus.SC_BAD_REQUEST);
         assertValidationErrorField(response, "validateRequestSingleParam.param", "Param must have 3 characters");
     }
@@ -46,7 +46,7 @@ public class ValidationOnRequestParamRouteHandlerTest {
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .extract().as(ValidationErrorResponse.class);
         assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
+        assertValidationErrorDetail(response);
         assertValidationErrorStatus(response, HttpStatus.SC_BAD_REQUEST);
         assertValidationErrorField(response, "validateRequestMultipleParam.firstParam", "First param must have 3 characters");
         assertValidationErrorField(response, "validateRequestMultipleParam.secondParam", "Second param must match pattern");
@@ -70,7 +70,7 @@ public class ValidationOnRequestParamRouteHandlerTest {
                 .extract().as(ValidationErrorResponse.class);
 
         assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
+        assertValidationErrorDetail(response);
         assertValidationErrorStatus(response, HttpStatus.SC_BAD_REQUEST);
         assertValidationErrorField(response, "validateRequestSingleParamUsingCustomValidation.param",
                 "Value must be uppercase");

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnResponseRouteHandlerTest.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/ValidationOnResponseRouteHandlerTest.java
@@ -1,6 +1,6 @@
 package io.quarkus.qe.validation;
 
-import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorDetails;
+import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorDetail;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorField;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorStatus;
 import static io.quarkus.qe.validation.utils.ValidationAssertions.assertValidationErrorTitle;
@@ -34,7 +34,7 @@ public class ValidationOnResponseRouteHandlerTest {
                 .extract().as(ValidationErrorResponse.class);
 
         assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
+        assertValidationErrorDetail(response);
         assertValidationErrorStatus(response, HttpStatus.SC_INTERNAL_SERVER_ERROR);
         assertValidationErrorField(response, "id", "id can't be null");
     }
@@ -50,7 +50,7 @@ public class ValidationOnResponseRouteHandlerTest {
                 .extract().as(ValidationErrorResponse.class);
 
         assertValidationErrorTitle(response);
-        assertValidationErrorDetails(response);
+        assertValidationErrorDetail(response);
         assertValidationErrorStatus(response, HttpStatus.SC_INTERNAL_SERVER_ERROR);
     }
 }

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/utils/ValidationAssertions.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/utils/ValidationAssertions.java
@@ -16,8 +16,8 @@ public class ValidationAssertions {
         assertEquals("Constraint Violation", response.getTitle());
     }
 
-    public static final void assertValidationErrorDetails(ValidationErrorResponse response) {
-        assertEquals("validation constraint violations", response.getDetails());
+    public static final void assertValidationErrorDetail(ValidationErrorResponse response) {
+        assertEquals("validation constraint violations", response.getDetail());
     }
 
     public static final void assertValidationErrorStatus(ValidationErrorResponse response, int expected) {

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/utils/ValidationErrorResponse.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/utils/ValidationErrorResponse.java
@@ -2,7 +2,7 @@ package io.quarkus.qe.validation.utils;
 
 public class ValidationErrorResponse {
     private String title;
-    private String details;
+    private String detail;
     private int status;
     private ValidationError[] violations;
 
@@ -14,12 +14,12 @@ public class ValidationErrorResponse {
         this.title = title;
     }
 
-    public String getDetails() {
-        return details;
+    public String getDetail() {
+        return detail;
     }
 
-    public void setDetails(String details) {
-        this.details = details;
+    public void setDetail(String detail) {
+        this.detail = detail;
     }
 
     public int getStatus() {

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,8 @@
         <module>300-quarkus-vertx-webClient</module>
         <module>301-quarkus-vertx-kafka</module>
         <module>302-quarkus-vertx-jwt</module>
-        <!-- TODO: https://github.com/quarkusio/quarkus/issues/21516 -->
-        <!--<module>303-quarkus-vertx-sql</module>
-        <module>304-quarkus-vertx-routes</module> -->
+        <module>303-quarkus-vertx-sql</module>
+        <module>304-quarkus-vertx-routes</module>
         <module>601-spring-data-primitive-types</module>
         <module>602-spring-data-rest</module>
         <module>603-spring-web-smallrye-openapi</module>


### PR DESCRIPTION
Today [Bitnami migrated](https://github.com/bitnami-labs/sealed-secrets/issues/822#issuecomment-1104116084) their images to [Dockerhub Bitnami](https://hub.docker.com/u/bitnami). The migration caused several test errors in [beefy-scenarios](https://github.com/quarkus-qe/beefy-scenarios), more specifically:

- `014-quarkus-panache-with-transactions-xa` failed due to missing `quay.io/bitnami/mysql:5.7.32`
- `019-quarkus-consul` failed due to missing `quay.io/bitnami/consul:1.9.3`
- `302-quarkus-vertx-jwt` failed due to missing `quay.io/bitnami/redis:6.0`
- `002-quarkus-all-extensions` failed due to missing `quay.io/bitnami/mongodb:4.0.23`

while I didn't find connect between migration and following failures (so far, there might be correlation between `302-quarkus-vertx-jwt` and other `vertx` failures): 

- `013-quarkus-oidc-restclient`
- `300-quarkus-vertx-webclient`
- `301-quarkus-vertx-kafka`

This PR migrates Bitnami images to the official ones:
quay.io/bitnami/mongodb:4.0.23 ----> mongo:4.0.23
quay.io/bitnami/mysql:5.7.32 -------> mysql:5.7 ([change suggested here](https://github.com/quarkus-qe/quarkus-test-suite/pull/608#discussion_r855145711))
quay.io/bitnami/postgresql:13.4.0 ----> postgres:13.6 ([mirroring changes made here](https://github.com/quarkus-qe/quarkus-test-suite/pull/608/files))
quay.io/bitnami/mysql:8.0 ----->   mysql:8.0
quay.io/bitnami/consul:1.9.3 ----> 1.9.3
quay.io/bitnami/redis:6.0 ----> redis:6.0
