### PR TITLE
Application name is now propagated in JVM tests

### DIFF
--- a/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceTest.java
+++ b/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceTest.java
@@ -172,7 +172,6 @@ public class ChuckNorrisResourceTest {
     }
 
     private String getServiceName() {
-        // TODO https://github.com/quarkusio/quarkus/issues/16499
-        return (IS_NATIVE) ? "300-quarkus-vertx-webclient" : "<<unset>>";
+        return "300-quarkus-vertx-webclient";
     }
 }

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/KafkaCommonTest.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/KafkaCommonTest.java
@@ -104,8 +104,7 @@ abstract class KafkaCommonTest {
     }
 
     private String getServiceName() {
-        // TODO https://github.com/quarkusio/quarkus/issues/16499
-        return isNativeTest() ? "301-quarkus-vertx-kafka" : "<<unset>>";
+        return "301-quarkus-vertx-kafka";
     }
 
     private void sendAndReceiveEvents(int timeoutMin, int expectedEventsAmount) throws InterruptedException {


### PR DESCRIPTION
Application name is now propagated in JVM tests

Details in https://github.com/quarkusio/quarkus/issues/25097

I first thought there was a bug in Quarkus main, but the change goes in the right direction and we need to update the tests.