### PR TITLE
Revert "Disable native because of broken opentelemetry-exporter-jaeger"

### DIFF
--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -107,17 +107,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <!--        TODO remove - https://github.com/quarkusio/quarkus/issues/25143 -->
-            <id>native</id>
-            <activation>
-                <property>
-                    <name>native</name>
-                </property>
-            </activation>
-            <properties>
-                <quarkus.package.type>native-sources</quarkus.package.type>
-            </properties>
-        </profile>
     </profiles>
 </project>

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeConfluentKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeConfluentKafkaIT.java
@@ -1,11 +1,8 @@
 package io.quarkus.qe.kafka;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-@Disabled("https://github.com/quarkusio/quarkus/issues/25143")
 public class NativeConfluentKafkaIT extends ConfluentKafkaTest {
 
     @Override

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeStrimziKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeStrimziKafkaIT.java
@@ -1,11 +1,8 @@
 package io.quarkus.qe.kafka;
 
-import org.junit.jupiter.api.Disabled;
-
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-@Disabled("https://github.com/quarkusio/quarkus/issues/25143")
 public class NativeStrimziKafkaIT extends StrimziKafkaTest {
 
     @Override


### PR DESCRIPTION
Revert "Disable native because of broken opentelemetry-exporter-jaeger"

This reverts commit dabebde178288c6ffbc518a58d427c5b8e63ab23.
https://github.com/quarkusio/quarkus/issues/25143 is fixed now in Quarkus main