### PR TITLE
Fix 302-quarkus-vertx-jwt start up by reordering Vert.X Web handler

### DIFF
--- a/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/Application.java
+++ b/302-quarkus-vertx-jwt/src/main/java/io/quarkus/qe/vertx/web/Application.java
@@ -87,8 +87,8 @@ public class Application {
 
     private void addRoute(HttpMethod method, String path, AUTH authEnabled, Handler<RoutingContext> handler) {
         Route route = this.router.route(method, path)
-                .handler(CorsHandler.create("*"))
-                .handler(LoggerHandler.create());
+                .handler(LoggerHandler.create())
+                .handler(CorsHandler.create("*"));
 
         if (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT))
             route.handler(BodyHandler.create());


### PR DESCRIPTION
Two days ago Vert.X were [bumped to 4.3.1](https://github.com/quarkusio/quarkus/pull/26294) that caused errors in CI daily runs. According to the [4.3 release notes](https://vertx.io/blog/whats-new-in-vert-x-4-3/#vertx-web) the handler order matters, I also found similar issue [reported here](https://github.com/vert-x3/vertx-web/issues/2182). Security policy handler `CorsHandler` should be registered after the logging handler.