### PR TITLE
Update native image builders - use version 22.2

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.3-java11", "ubi-quarkus-mandrel:21.3-java11" ]
+        image: [ "ubi-quarkus-native-image:22.2-java11", "ubi-quarkus-mandrel:22.2-java11" ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -172,7 +172,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: ["21.3.0.java11"]
+        graalvm-version: ["22.2.0.java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:21.3-java11"]
+        image: [ "ubi-quarkus-native-image:22.2-java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
@@ -140,7 +140,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: ["21.3.0.java11"]
+        graalvm-version: ["22.2.0.java11"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
Updates GraalVM/Mandrel version to 22.2.