### PR TITLE
Add dependabot to the repository for Maven dependencies and GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Maintain dependencies for Maven
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # For Quarkus Maven Plugin, updates are managed by Quarkus Bom dependency
+      - dependency-name: io.quarkus:quarkus-maven-plugin
+      # This dependency is used in `lifecycle-application` to verify Maven errors, we need to ignore it
+      - dependency-name: io.quarkus:quarkus-spring-di
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Summary

Adding dependabot to maintain and keep Github actions up to date along with the Maven dependencies.

Please select the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update
- [ ] Refactoring
- [ ] Backport
- [ ] New scenario (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires execution against OCP (use `run tests` phrase in comment)

### Checklist:
- [ ] Methods and classes used in PR scenarios are meaningful
- [x] Commits are well encapsulated and follow [the best practices](https://cbea.ms/git-commit/)