### PR TITLE
Remove non-used GHA for Windows Native build

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -199,9 +199,6 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Install cl.exe
-        uses: ilammy/msvc-dev-cmd@v1
-      - uses: microsoft/setup-msbuild@v1
       - name: Setup GraalVM
         id: setup-graalvm
         uses: graalvm/setup-graalvm@v1
@@ -209,9 +206,6 @@ jobs:
           version: ${{ matrix.graalvm-version }}
           java-version: ${{ matrix.graalvm-java-version }}
           components: 'native-image'
-      - name: Install native-image component
-        run: |
-          gu.cmd install native-image
       - name: Configure Pagefile
         # Increased the page-file size due to memory-consumption of native-image command
         # For details see https://github.com/actions/virtual-environments/issues/785

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -170,9 +170,6 @@ jobs:
         shell: bash
         run: |
           mvn -fae -V -B -s .github/mvn-settings.xml clean test
-      - name: Install cl.exe
-        uses: ilammy/msvc-dev-cmd@v1
-      - uses: microsoft/setup-msbuild@v1
       - name: Setup GraalVM
         id: setup-graalvm
         uses: graalvm/setup-graalvm@v1
@@ -180,9 +177,6 @@ jobs:
           version: ${{ matrix.graalvm-version }}
           java-version: ${{ matrix.graalvm-java-version }}
           components: 'native-image'
-      - name: Install native-image component
-        run: |
-          gu.cmd install native-image
       - name: Configure Pagefile
         # Increased the page-file size due to memory-consumption of native-image command
         # For details see https://github.com/actions/virtual-environments/issues/785


### PR DESCRIPTION
Follows up of https://github.com/quarkus-qe/beefy-scenarios/pull/309

As a [`graalvm/setup-graalvm`](https://github.com/graalvm/setup-graalvm) GHA was introduced, we need to get rid of the non used GHA actions for Windows, as they are now already available when using this GHA