### PR TITLE
Fix changed modules detection in PRs and run only necessary CI modules

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -118,7 +118,7 @@ jobs:
 
           for module in $MODULES
           do
-              if [[ "${{ steps.files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
+              if [[ "${{ steps.changed-files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
                   CHANGED=$(echo $CHANGED" "$module)
               fi
           done


### PR DESCRIPTION
Fix based on the example https://github.com/tj-actions/changed-files#usage.