### PR TITLE
Revert "Fix changed modules detection in PRs and run only necessary"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -118,7 +118,7 @@ jobs:
 
           for module in $MODULES
           do
-              if [[ "${{ steps.changed-files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
+              if [[ "${{ steps.files.outputs.all_changed_and_modified_files }}" =~ ("$module") ]] ; then
                   CHANGED=$(echo $CHANGED" "$module)
               fi
           done


### PR DESCRIPTION
This reverts commit 90938352c7c61bd25a5c9ad41b190d476a6c9405.

Now that I understand the problem, only Quarkus QE Test Suite was affected as this PR workflow does not output changes. I'm very sorry.