### PR TITLE
Move to new builder images introduced in Quarkus 2.14

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:22.3-java17", "ubi-quarkus-mandrel:22.3-java17" ]
+        image: [ "ubi-quarkus-graalvmce-builder-image:22.3-java17", "ubi-quarkus-mandrel-builder-image:22.3-java17" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        image: [ "ubi-quarkus-native-image:22.3-java17"]
+        image: [ "ubi-quarkus-mandrel-builder-image:22.3-java17"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3


### PR DESCRIPTION
Move to new builder images introduced in Quarkus 2.14

PR with the change - https://github.com/quarkusio/quarkus/pull/27997

NEW is active - https://quay.io/repository/quarkus/ubi-quarkus-mandrel-builder-image?tab=tags
OLD is without update for 3 months - https://quay.io/repository/quarkus/ubi-quarkus-mandrel?tab=tags