### PR TITLE
Use Java 17 based GraalVM on Windows for Daily

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -176,8 +176,8 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: [ "22.3.0" ]
-        graalvm-java-version: [ "11" ]
+        graalvm-version: [ "22.3.1" ]
+        graalvm-java-version: [ "17" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3


### PR DESCRIPTION
Use Java 17 based GraalVM on Windows for Daily