### PR TITLE
Replace deprecated @NativeImageTest with @QuarkusIntegrationTest

### DIFF
--- a/001-quarkus-getting-started-with-jaxrs/src/test/java/io/quarkus/qe/core/NativeAsciiMultipartResourceIT.java
+++ b/001-quarkus-getting-started-with-jaxrs/src/test/java/io/quarkus/qe/core/NativeAsciiMultipartResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeAsciiMultipartResourceIT extends AsciiMultipartResourceTest {
 
 }

--- a/001-quarkus-getting-started-with-jaxrs/src/test/java/io/quarkus/qe/core/NativeBaseQuarkusBundleIT.java
+++ b/001-quarkus-getting-started-with-jaxrs/src/test/java/io/quarkus/qe/core/NativeBaseQuarkusBundleIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeBaseQuarkusBundleIT extends BaseQuarkusBundleTest {
 
     // Execute the same tests but in native mode.

--- a/001-quarkus-getting-started-with-jaxrs/src/test/java/io/quarkus/qe/core/NativeMultipartResourceIT.java
+++ b/001-quarkus-getting-started-with-jaxrs/src/test/java/io/quarkus/qe/core/NativeMultipartResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeMultipartResourceIT extends MultipartResourceTest {
 }

--- a/002-quarkus-all-extensions/src/test/java/io/quarkus/qe/core/NativeAlmostAllQuarkusExtensionsIT.java
+++ b/002-quarkus-all-extensions/src/test/java/io/quarkus/qe/core/NativeAlmostAllQuarkusExtensionsIT.java
@@ -2,10 +2,10 @@ package io.quarkus.qe.core;
 
 import org.junit.jupiter.api.Disabled;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @Disabled("TODO: Caused by REST endpoints are not exposed in Native")
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeAlmostAllQuarkusExtensionsIT extends AlmostAllQuarkusExtensionsTest {
 
     // Execute the same tests but in native mode.

--- a/003-quarkus-many-extensions/src/test/java/io/quarkus/qe/many/extensions/NativeManyExtensionsResourceIT.java
+++ b/003-quarkus-many-extensions/src/test/java/io/quarkus/qe/many/extensions/NativeManyExtensionsResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.many.extensions;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeManyExtensionsResourceIT extends ManyExtensionsResourceTest {
 
     // Execute the same tests but in native mode.

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/items/NativeItemsResourceIT.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/items/NativeItemsResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.hibernate.items;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeItemsResourceIT extends ItemsResourceTest {
 }

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/transaction/NativeTransactionScopeBeanResourceIT.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/transaction/NativeTransactionScopeBeanResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.hibernate.transaction;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeTransactionScopeBeanResourceIT extends TransactionScopeBeanResourceTest {
 
 }

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/validator/NativeJpaAndHibernateValidatorResourceIT.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/validator/NativeJpaAndHibernateValidatorResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.hibernate.validator;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeJpaAndHibernateValidatorResourceIT extends JpaAndHibernateValidatorResourceTest {
 
     // Execute the same tests but in native mode.

--- a/005-quarkus-and-maven-profiles/src/test/java/io/quarkus/qe/core/NativeQuarkusAndMavenProfilesIT.java
+++ b/005-quarkus-and-maven-profiles/src/test/java/io/quarkus/qe/core/NativeQuarkusAndMavenProfilesIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeQuarkusAndMavenProfilesIT extends QuarkusAndMavenProfilesTest {
 
     // Execute the same tests but in native mode.

--- a/006-quartz-manually-scheduled-job/src/test/java/io/quarkus/qe/quartz/QuartzITCase.java
+++ b/006-quartz-manually-scheduled-job/src/test/java/io/quarkus/qe/quartz/QuartzITCase.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.quartz;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class QuartzITCase extends QuartzTestCase {
 
 }

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeReactivePingPongResourceOpentracingIT.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeReactivePingPongResourceOpentracingIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeReactivePingPongResourceOpentracingIT extends ReactivePingPongResourceOpentracingTest {
 }

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeRestPingPongResourceOpentracingIT.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeRestPingPongResourceOpentracingIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeRestPingPongResourceOpentracingIT extends RestPingPongResourceOpentracingTest {
 }

--- a/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeServerSentEventsPingPongResourceOpentracingIT.java
+++ b/010-quarkus-opentracing-reactive-grpc/src/test/java/io/quarkus/qe/NativeServerSentEventsPingPongResourceOpentracingIT.java
@@ -2,9 +2,9 @@ package io.quarkus.qe;
 
 import org.junit.jupiter.api.Disabled;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 @Disabled("https://github.com/quarkusio/quarkus/issues/30935")
 public class NativeServerSentEventsPingPongResourceOpentracingIT extends ServerSentEventsPingPongResourceOpentracingTest {
 

--- a/011-quarkus-panache-rest-flyway/src/test/java/io/quarkus/qe/NativePostgreSqlApplicationResourceIT.java
+++ b/011-quarkus-panache-rest-flyway/src/test/java/io/quarkus/qe/NativePostgreSqlApplicationResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativePostgreSqlApplicationResourceIT extends PostgreSqlApplicationResourceTest {
 
 }

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeAutoAcquireTokenPingPongResourceIT.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeAutoAcquireTokenPingPongResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeAutoAcquireTokenPingPongResourceIT extends AutoAcquireTokenPingPongResourceTest {
 }

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeLookupAuthorizationRestPingPongResourceIT.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeLookupAuthorizationRestPingPongResourceIT.java
@@ -2,9 +2,9 @@ package io.quarkus.qe;
 
 import org.junit.jupiter.api.Disabled;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
 @Disabled("Annotation @ClientHeaderParam not working in Native. Reported by https://github.com/quarkusio/quarkus/issues/13660")
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeLookupAuthorizationRestPingPongResourceIT extends LookupAuthorizationRestPingPongResourceTest {
 }

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeReactivePingPongResourceOidcIT.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeReactivePingPongResourceOidcIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeReactivePingPongResourceOidcIT extends ReactivePingPongResourceOidcTest {
 }

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeRestPingPongResourceOidcIT.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeRestPingPongResourceOidcIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeRestPingPongResourceOidcIT extends RestPingPongResourceOidcTest {
 }

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeTokenPropagationPingPongResourceIT.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/NativeTokenPropagationPingPongResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeTokenPropagationPingPongResourceIT extends TokenPropagationPingPongResourceTest {
 }

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/OpenApiTestIT.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/OpenApiTestIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class OpenApiTestIT extends OpenApiTest {
 
 }

--- a/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/NativeMySqlApplicationResourceIT.java
+++ b/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/NativeMySqlApplicationResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeMySqlApplicationResourceIT extends MySqlApplicationResourceTest {
 
 }

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeHttpServerMetricsIT.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeHttpServerMetricsIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeHttpServerMetricsIT extends HttpServerMetricsTest {
 
 }

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeUsingMicroProfilePingPongResourceIT.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeUsingMicroProfilePingPongResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeUsingMicroProfilePingPongResourceIT extends UsingMicroProfilePingPongResourceTest {
 
 }

--- a/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeUsingRegistryPingPongResourceIT.java
+++ b/015-quarkus-micrometer/src/test/java/io/quarkus/qe/NativeUsingRegistryPingPongResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeUsingRegistryPingPongResourceIT extends UsingRegistryPingPongResourceTest {
 
 }

--- a/021-quarkus-panache-multiple-pus/src/test/java/io/quarkus/qe/multiplepus/MultiplePersistenceUnitIT.java
+++ b/021-quarkus-panache-multiple-pus/src/test/java/io/quarkus/qe/multiplepus/MultiplePersistenceUnitIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.multiplepus;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class MultiplePersistenceUnitIT extends MultiplePersistenceUnitTest {
 }

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeBindMapsUsingConfigValueIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeBindMapsUsingConfigValueIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.bulk;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeBindMapsUsingConfigValueIT extends BindMapsUsingConfigValueTest {
 }

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeBulkOfPropertiesIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeBulkOfPropertiesIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.bulk;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeBulkOfPropertiesIT extends BulkOfPropertiesTest {
 
 }

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeConfigValueIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/bulk/NativeConfigValueIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.bulk;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeConfigValueIT extends ConfigValueTest {
 
     @Override

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/config/VariousConfigurationSourcesTestIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/config/VariousConfigurationSourcesTestIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.config;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class VariousConfigurationSourcesTestIT extends VariousConfigurationSourcesTest {
 
     // Execute the same tests but in native mode.

--- a/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/NativeConfigMappingResourceIT.java
+++ b/022-quarkus-properties-config-all/src/test/java/io/quarkus/qe/configmapping/NativeConfigMappingResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.configmapping;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeConfigMappingResourceIT extends ConfigMappingResourceTest {
 }

--- a/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeFallbackResourceIT.java
+++ b/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeFallbackResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeFallbackResourceIT extends FallbackResourceTest {
 
 }

--- a/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeInjectingScopedBeansResourceIT.java
+++ b/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeInjectingScopedBeansResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeInjectingScopedBeansResourceIT extends InjectingScopedBeansResourceTest {
 
 }

--- a/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeJavaEELikeHealthCheckTestIT.java
+++ b/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeJavaEELikeHealthCheckTestIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeJavaEELikeHealthCheckTestIT extends JavaEELikeHealthCheckTest {
 
     // Execute the same tests but in native mode.

--- a/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeJavaEELikeQuarkusBundleIT.java
+++ b/101-javaee-like-getting-started/src/test/java/io/quarkus/qe/core/NativeJavaEELikeQuarkusBundleIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.core;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeJavaEELikeQuarkusBundleIT extends JavaEELikeQuarkusBundleTest {
 
     // Execute the same tests but in native mode.

--- a/201-large-static-content/src/test/java/io/quarkus/qe/content/NativeLargeStaticResourceIT.java
+++ b/201-large-static-content/src/test/java/io/quarkus/qe/content/NativeLargeStaticResourceIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.content;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeLargeStaticResourceIT extends LargeStaticResourceTest {
 
     // Execute the same tests but in native mode.

--- a/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
+++ b/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceIT.java
@@ -7,9 +7,9 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ChuckNorrisResourceIT extends ChuckNorrisResourceTest {
 
     private static final String DEBUG_SYMBOLS_FILE_NAME = "300-quarkus-vertx-webclient-1.0.0-SNAPSHOT-runner.debug";

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeConfluentKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeConfluentKafkaIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.kafka;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeConfluentKafkaIT extends ConfluentKafkaTest {
 
     @Override

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeStrimziKafkaIT.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/NativeStrimziKafkaIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.kafka;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeStrimziKafkaIT extends StrimziKafkaTest {
 
     @Override

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/BladeRunnerHandlerIT.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/BladeRunnerHandlerIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.vertx.web;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class BladeRunnerHandlerIT extends BladeRunnerHandlerTest {
 }

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/NoSecureResourceIT.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/NoSecureResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.vertx.web;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NoSecureResourceIT extends NoSecuredResourceTest {
 }

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/ReplicantHandlerIT.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/ReplicantHandlerIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.vertx.web;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class ReplicantHandlerIT extends ReplicantHandlerTest {
 }

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/SecuredResourceIT.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/SecuredResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.vertx.web;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class SecuredResourceIT extends SecuredResourceTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/NativeDb2HandlerIT.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/NativeDb2HandlerIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeDb2HandlerIT extends Db2HandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/NativeMysqlHandlerIT.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/NativeMysqlHandlerIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeMysqlHandlerIT extends MysqlHandlerTest {
 }

--- a/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/NativePostgresqlHandlerIT.java
+++ b/303-quarkus-vertx-sql/src/test/java/io/quarkus/qe/vertx/sql/handlers/NativePostgresqlHandlerIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.vertx.sql.handlers;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativePostgresqlHandlerIT extends PostgresqlHandlerTest {
 }

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/NativeValidationOnRequestBodyRouteHandlerIT.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/NativeValidationOnRequestBodyRouteHandlerIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.validation;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeValidationOnRequestBodyRouteHandlerIT extends ValidationOnRequestBodyRouteHandlerTest {
 
 }

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/NativeValidationOnRequestParamRouteHandlerIT.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/NativeValidationOnRequestParamRouteHandlerIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.validation;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeValidationOnRequestParamRouteHandlerIT extends ValidationOnRequestParamRouteHandlerTest {
 
 }

--- a/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/NativeValidationOnResponseRouteHandlerIT.java
+++ b/304-quarkus-vertx-routes/src/test/java/io/quarkus/qe/validation/NativeValidationOnResponseRouteHandlerIT.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.validation;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeValidationOnResponseRouteHandlerIT extends ValidationOnResponseRouteHandlerTest {
 
 }

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/BookResourceIT.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/BookResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class BookResourceIT extends BookResourceTest {
 }

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CatResourceIT.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CatResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CatResourceIT extends CatResourceTest {
 }

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersIT.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class CommonsHeadersIT extends CommonsHeadersTest {
 }

--- a/602-spring-data-rest/src/test/java/org/acme/spring/data/rest/NativeBookRepositoryTestIT.java
+++ b/602-spring-data-rest/src/test/java/org/acme/spring/data/rest/NativeBookRepositoryTestIT.java
@@ -1,7 +1,7 @@
 package org.acme.spring.data.rest;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeBookRepositoryTestIT extends BookRepositoryTest {
 }

--- a/602-spring-data-rest/src/test/java/org/acme/spring/data/rest/NativeLibraryRepositoryTestIT.java
+++ b/602-spring-data-rest/src/test/java/org/acme/spring/data/rest/NativeLibraryRepositoryTestIT.java
@@ -1,8 +1,8 @@
 package org.acme.spring.data.rest;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeLibraryRepositoryTestIT extends LibraryRepositoryTest {
 
 }

--- a/603-spring-web-smallrye-openapi/src/test/java/io/quarkus/qe/books/NativeBookResourceIT.java
+++ b/603-spring-web-smallrye-openapi/src/test/java/io/quarkus/qe/books/NativeBookResourceIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.books;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeBookResourceIT extends BookResourceTest {
 }

--- a/603-spring-web-smallrye-openapi/src/test/java/io/quarkus/qe/books/NativeHomePageIT.java
+++ b/603-spring-web-smallrye-openapi/src/test/java/io/quarkus/qe/books/NativeHomePageIT.java
@@ -1,7 +1,7 @@
 package io.quarkus.qe.books;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeHomePageIT extends HomePageTest {
 }

--- a/603-spring-web-smallrye-openapi/src/test/java/org/acme/spring/web/NativeOpenApiIT.java
+++ b/603-spring-web-smallrye-openapi/src/test/java/org/acme/spring/web/NativeOpenApiIT.java
@@ -1,7 +1,7 @@
 package org.acme.spring.web;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeOpenApiIT extends OpenApiTest {
 }


### PR DESCRIPTION
Fixes native integration tests.

Deprecated `@NativeImageTest` has been removed from Quarkus in https://github.com/quarkusio/quarkus/pull/31048.