### PR TITLE
Remove quarkus-opentelemetry-exporter-otlp and fix traces operation name in one module

### DIFF
--- a/300-quarkus-vertx-webClient/pom.xml
+++ b/300-quarkus-vertx-webClient/pom.xml
@@ -14,10 +14,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>

--- a/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceTest.java
+++ b/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceTest.java
@@ -88,7 +88,7 @@ public class ChuckNorrisResourceTest {
     @Test
     public void endpointShouldTrace() {
         final int pageLimit = 50;
-        final String expectedOperationName = "/trace/ping";
+        final String expectedOperationName = "GET /trace/ping";
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
             thenRetrieveTraces(pageLimit, "1h", getServiceName(), expectedOperationName);
@@ -104,7 +104,7 @@ public class ChuckNorrisResourceTest {
     @Test
     public void httpClientShouldHaveHisOwnSpan() {
         final int pageLimit = 50;
-        final String expectedOperationName = "/trace/ping";
+        final String expectedOperationName = "GET /trace/ping";
         await().atMost(1, TimeUnit.MINUTES).pollInterval(Duration.ofSeconds(1)).untilAsserted(() -> {
             whenIMakePingRequest();
             thenRetrieveTraces(pageLimit, "1h", getServiceName(), expectedOperationName);

--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -23,10 +23,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Quarkus OpenTelemetry now contains OTLP exported, there is no need to extra dependency
- Fix traces operation name in module `300-quarkus-vertx-webclient` after OT bump to the 1.23.1 - https://github.com/quarkusio/quarkus/pull/31356

I'm also aware there is issue with traces operation name in module 301, but I will address it in a separate PR as I'm having issue to run these tests at all (I hit serialization problems).