### PR TITLE
Remove the outdated property

### DIFF
--- a/603-spring-web-smallrye-openapi/src/main/resources/application.properties
+++ b/603-spring-web-smallrye-openapi/src/main/resources/application.properties
@@ -2,7 +2,6 @@ spring.application.name = Bootstrap Spring Boot
 
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:bootapp;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-%prod.quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 


### PR DESCRIPTION
Property %prod.quarkus.datasource.jdbc.url was used by integration tests as a workaround for connecting to H2 database.
Due to new changes, the profile we use now is `native` instead of `prod`, and this property leads to failures.

[1] https://github.com/quarkusio/quarkus/pull/31465