### PR TITLE
Fix MultiplePersistenceUnitTest by removing workaround that adds a gap of 50 as pool optimizer now uses pooled-lo strategy

### DIFF
--- a/021-quarkus-panache-multiple-pus/src/main/resources/import-fruits.sql
+++ b/021-quarkus-panache-multiple-pus/src/main/resources/import-fruits.sql
@@ -5,4 +5,4 @@ INSERT INTO fruit (id, name) VALUES (4, 'Plum');
 INSERT INTO fruit (id, name) VALUES (5, 'Cherry');
 INSERT INTO fruit (id, name) VALUES (6, 'Berry');
 INSERT INTO fruit (id, name) VALUES (7, 'Cranberry');
-ALTER SEQUENCE fruit_SEQ RESTART WITH 57; -- 7 + pool size TODO: https://github.com/quarkusio/quarkus/issues/31481
+ALTER SEQUENCE fruit_SEQ RESTART WITH 8;

--- a/021-quarkus-panache-multiple-pus/src/main/resources/import-vegetables.sql
+++ b/021-quarkus-panache-multiple-pus/src/main/resources/import-vegetables.sql
@@ -6,4 +6,4 @@ INSERT INTO vegetable (id, name) VALUES (nextval('Vegetable_SEQ'), 'Kohlrabi');
 INSERT INTO vegetable (id, name) VALUES (nextval('Vegetable_SEQ'), 'Leek');
 INSERT INTO vegetable (id, name) VALUES (nextval('Vegetable_SEQ'), 'Onion');
 INSERT INTO vegetable (id, name) VALUES (nextval('Vegetable_SEQ'), 'Garlic');
-ALTER SEQUENCE Vegetable_SEQ RESTART with 57; -- 7 + pool size TODO: https://github.com/quarkusio/quarkus/issues/31481
+ALTER SEQUENCE Vegetable_SEQ RESTART with 8;


### PR DESCRIPTION
Quarkus now defaults to [pooled-lo pool optimizer](https://github.com/quarkusio/quarkus/issues/31899) that avoid unsigned ids, so our workaround does not force ids of newly created rows (that's one created by application logic, not init script) to start right after rows inserted by init script. This PR updates next expected id so that next id is inserted right after the rows inserted by init script.