### PR TITLE
Explicit request uri, REST Assured defaults to app root path

### DIFF
--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/LegacyNonApplicationEndpointTest.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/non_application/endpoint/LegacyNonApplicationEndpointTest.java
@@ -24,6 +24,6 @@ public class LegacyNonApplicationEndpointTest {
 
     @Test
     protected void nonAppEndpointScenario() {
-        when().get("/health").then().statusCode(200);
+        when().get("http://localhost:8081/health").then().statusCode(200);
     }
 }


### PR DESCRIPTION
Explicit request uri, REST Assured defaults to app root path

This change starts with https://github.com/quarkusio/quarkus/commit/09fb41167ca41c1a794799f0555d5783b8c8b6fb
I think the change is correct as the application root path should be used by default.

Before the change the Request URI was http://localhost:8081/health
After the change the Request URI is http://localhost:8081/api/health ... includes `/api`

REST Assured defaults to application root path for `QuarkusProdModeTest` now. Checked also standalone app with `@QuarkusTest` and Request URI is http://localhost:8081/api/health including Quarkus 2.16.0.Final. So the https://github.com/quarkusio/quarkus/commit/09fb41167ca41c1a794799f0555d5783b8c8b6fb change fixes the behavior for `QuarkusProdModeTest`.

```properties
quarkus.http.root-path=/api
quarkus.smallrye-health.root-path=/health
```

```java
given()
          .log().all()
          .when().get("/health")
...
```