### PR TITLE
Drop neo4j as relocations were removed

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -142,10 +142,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-neo4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-orm</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Drop neo4j as relocations for Quarkus 1.x extensions were removed

https://github.com/quarkusio/quarkus/tree/main/relocations now covers just the latest changes done for Quarkus 2.x