### PR TITLE
Add retention-days for maven repo artifact

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           name: maven-repo
           path: maven-repo.tgz
+          retention-days: 1
   linux-build-jvm:
     name: Daily - Linux - JVM build
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           name: maven-repo
           path: maven-repo.tgz
+          retention-days: 1
   linux-build-jvm:
     name: PR - Linux - JVM build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add retention-days for storing maven repo artifact (1GB)

The default retention policy is 90 days - https://github.com/actions/upload-artifact#retention-period