### PR TITLE
Kubernetes resource name no longer depends on container image name

### DIFF
--- a/020-quarkus-http-non-application-endpoints/src/main/resources/application.properties
+++ b/020-quarkus-http-non-application-endpoints/src/main/resources/application.properties
@@ -1,4 +1,6 @@
+quarkus.container-image.group=qe
 quarkus.container-image.name=demo
+quarkus.container-image.tag=1.0.0
 quarkus.application.name=non-application endpoints
 quarkus.http.root-path=/api
 quarkus.http.non-application-root-path=/q

--- a/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/openshift/OpenShiftYamlHealthProbesIT.java
+++ b/020-quarkus-http-non-application-endpoints/src/test/java/io/quarkus/qe/openshift/OpenShiftYamlHealthProbesIT.java
@@ -37,7 +37,10 @@ public class OpenShiftYamlHealthProbesIT {
 
                 // finalMap.entrySet().forEach(System.out::println);
 
-                assertEquals("demo", finalMap.get("name"), "Deployment name is not expected 'demo'");
+                assertEquals("non-application endpoints", finalMap.get("name"),
+                        "Deployment name is different than expected 'non-application endpoints'");
+                assertEquals("qe/demo:1.0.0", finalMap.get("image"),
+                        "Deployment image is different than expected 'qe/demo:1.0.0'");
                 assertTrue(finalMap.containsKey("livenessProbe"), "livenessProbe is not defined");
                 assertTrue(finalMap.containsKey("readinessProbe"), "readinessProbe is not defined");
             }


### PR DESCRIPTION
Kubernetes resource name no longer depends on container image name

Change was done in https://github.com/quarkusio/quarkus/pull/33724