### PR TITLE
Remove elasticsearch-rest-high-level-client dependency

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -418,10 +418,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-elasticsearch-rest-high-level-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-ldap</artifactId>
         </dependency>
         <!--        Multiple producers of item class io.quarkus.vertx.http.deployment.RequireVirtualHttpBuildItem (io.quarkus.gcp.functions.http.deployment.GoogleCloudFunctionsHttpProcessor#requestVirtualHttp)-->


### PR DESCRIPTION
The extension has been removed from Quarkus in https://github.com/quarkusio/quarkus/pull/31997.