### PR TITLE
Change mandrel version in CI

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -179,7 +179,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: ["mandrel-latest"]
+        graalvm-version: ["mandrel-23.0.1.2-Final"]
         graalvm-java-version: [ "17" ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        graalvm-version: ["mandrel-latest"]
+        graalvm-version: ["mandrel-23.0.1.2-Final"]
         graalvm-java-version: [ "17" ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Change CI definition from latest mandrel version to specific version (23.0.1.2-Final) as the newest one was built only by JDK 21. This is specific for windows native.