### PR TITLE
Move to quarkus-resteasy-client based artifacts

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-resteasy-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -502,15 +502,15 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jackson</artifactId>
+            <artifactId>quarkus-resteasy-client-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jaxb</artifactId>
+            <artifactId>quarkus-resteasy-client-jaxb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-client-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/003-quarkus-many-extensions/pom.xml
+++ b/003-quarkus-many-extensions/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-resteasy-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/013-quarkus-oidc-restclient/pom.xml
+++ b/013-quarkus-oidc-restclient/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-mutiny</artifactId>
+            <artifactId>quarkus-resteasy-client-mutiny</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-client-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
Move to quarkus-resteasy-client based artifacts

There is big rename going on in Quarkus main / Quarkus 3.9 Let's use the new naming and not rely on relocations which can be deleted any day

002-quarkus-all-extensions fail is unfortunately expected, it's under investigation atm.

It seems that GraalVM upgrade is triggering passing full classpath and it fails on https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/java/io/quarkus/deployment/recording/BytecodeRecorderImpl.java#L681 for applications with big classpath, I will file issue for it once I find more details.