### PR TITLE
Add `CrudRepository` as Quarkus move spring data to version 3.2

### DIFF
--- a/602-spring-data-rest/src/main/java/org/acme/spring/data/rest/BookRepository.java
+++ b/602-spring-data-rest/src/main/java/org/acme/spring/data/rest/BookRepository.java
@@ -5,12 +5,13 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.data.rest.core.annotation.RestResource;
 
 @RepositoryRestResource(exported = false, path = "books", collectionResourceRel = "books")
-public interface BookRepository extends PagingAndSortingRepository<Book, Long> {
+public interface BookRepository extends PagingAndSortingRepository<Book, Long>, CrudRepository<Book, Long> {
 
     @Override
     @RestResource(exported = true)


### PR DESCRIPTION
Quarkus move spring-data from version 2.1.SP2 to 3.2.SP1. Now `PagingAndSortingRepository` no longer extends `CrudRepository`