### PR TITLE
Use a higher version of MariaDB instead of the default 10.3.6

### DIFF
--- a/021-quarkus-panache-multiple-pus/src/test/java/io/quarkus/qe/multiplepus/containers/MariaDbDatabaseTestResource.java
+++ b/021-quarkus-panache-multiple-pus/src/test/java/io/quarkus/qe/multiplepus/containers/MariaDbDatabaseTestResource.java
@@ -11,7 +11,7 @@ import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class MariaDbDatabaseTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final MariaDBContainer<?> DATABASE = new MariaDBContainer<>()
+    private static final MariaDBContainer<?> DATABASE = new MariaDBContainer<>("mariadb:10.11")
             .withDatabaseName("mariadb")
             .withUsername("mariadb")
             .withPassword("mariadb");


### PR DESCRIPTION
Use a higher version of MariaDB instead of the default 10.3.6

Fixes CI failure in 021-quarkus-panache-multiple-pus module:
`Caused by: io.quarkus.runtime.configuration.ConfigurationException: Persistence unit 'fruits' was configured to run with a database version of at least '10.6.0', but the actual version is '10.3.0'. Consider upgrading your database. Alternatively, rebuild your application with 'quarkus.datasource."fruits".db-version=10.3.0' (but this may disable some features and/or impact performance negatively).`

root cause: https://github.com/testcontainers/testcontainers-java/blob/main/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java#L21

`10.11` is used in https://github.com/quarkusio/quarkus/blob/main/build-parent/pom.xml#L93