### PR TITLE
Remove quarkus-opentelemetry-exporter-otlp 

### DIFF
--- a/300-quarkus-vertx-webClient/pom.xml
+++ b/300-quarkus-vertx-webClient/pom.xml
@@ -14,10 +14,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
By recent change https://github.com/quarkusio/quarkus/pull/41816 some old realocation were droped. The `quarkus-opentelemetry-exporter-otlp ` is not managed by `quarkus-bom`. By message this happend in 2.14 and [migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.14#opentelemetry-exporters-moved) mention it as well