### PR TITLE
Update deprecated `@QuarkusTestResource` to `@WithTestResource`

### DIFF
--- a/002-quarkus-all-extensions/src/test/java/io/quarkus/qe/core/AlmostAllQuarkusExtensionsTest.java
+++ b/002-quarkus-all-extensions/src/test/java/io/quarkus/qe/core/AlmostAllQuarkusExtensionsTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.core.containers.MongoTestResource;
 import io.quarkus.qe.core.containers.PostgreSqlDatabaseTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(value = MongoTestResource.class)
-@QuarkusTestResource(value = PostgreSqlDatabaseTestResource.class)
+@WithTestResource(value = MongoTestResource.class)
+@WithTestResource(value = PostgreSqlDatabaseTestResource.class)
 public class AlmostAllQuarkusExtensionsTest {
 
     @Test

--- a/004-quarkus-HHH-and-HV/README.md
+++ b/004-quarkus-HHH-and-HV/README.md
@@ -1,6 +1,6 @@
 # Quarkus - Hibernate and Hibernate Validator (lazy fetch strategy)
 This scenario uses in-memory Java database H2.  
-Test class annotated with `@QuarkusTestResource(H2DatabaseTestResource.class)` starts an in-memory H2 database
+Test class annotated with `@WithTestResource(H2DatabaseTestResource.class)` starts an in-memory H2 database
 
 Module that covers integration with some Hibernate features like:
 - Reproducer for [14201](https://github.com/quarkusio/quarkus/issues/14201) and [14881](https://github.com/quarkusio/quarkus/issues/14881): possible data loss bug in hibernate. This is covered under the Java package `io.quarkus.qe.hibernate.items`.

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/validator/TestResources.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/validator/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.hibernate.validator;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/006-quartz-manually-scheduled-job/src/test/java/io/quarkus/qe/quartz/TestResources.java
+++ b/006-quartz-manually-scheduled-job/src/test/java/io/quarkus/qe/quartz/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.quartz;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/011-quarkus-panache-rest-flyway/src/test/java/io/quarkus/qe/PostgreSqlApplicationResourceTest.java
+++ b/011-quarkus-panache-rest-flyway/src/test/java/io/quarkus/qe/PostgreSqlApplicationResourceTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.containers.PostgreSqlDatabaseTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
@@ -25,7 +25,7 @@ import io.restassured.specification.RequestSpecification;
 import jakarta.ws.rs.core.MediaType;
 
 @QuarkusTest
-@QuarkusTestResource(PostgreSqlDatabaseTestResource.class)
+@WithTestResource(PostgreSqlDatabaseTestResource.class)
 public class PostgreSqlApplicationResourceTest {
 
     private static final String APPLICATION_PATH = "/application";

--- a/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
+++ b/013-quarkus-oidc-restclient/src/test/java/io/quarkus/qe/AbstractPingPongResourceTest.java
@@ -14,12 +14,12 @@ import org.keycloak.authorization.client.AuthzClient;
 
 import io.quarkus.qe.containers.KeycloakTestResource;
 import io.quarkus.qe.model.Score;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.restassured.RestAssured;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.http.ContentType;
 
-@QuarkusTestResource(KeycloakTestResource.class)
+@WithTestResource(value = KeycloakTestResource.class, restrictToAnnotatedClass = false)
 public abstract class AbstractPingPongResourceTest {
 
     private static final String PING_ENDPOINT = "/%s-ping";

--- a/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/MySqlApplicationResourceTest.java
+++ b/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/MySqlApplicationResourceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.containers.MySqlDatabaseTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
@@ -21,7 +21,7 @@ import io.restassured.specification.RequestSpecification;
 import jakarta.ws.rs.core.MediaType;
 
 @QuarkusTest
-@QuarkusTestResource(MySqlDatabaseTestResource.class)
+@WithTestResource(MySqlDatabaseTestResource.class)
 public class MySqlApplicationResourceTest {
 
     private static final String APPLICATION_PATH = "/application";

--- a/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/rest/data/UserResourceTest.java
+++ b/014-quarkus-panache-with-transactions-xa/src/test/java/io/quarkus/qe/rest/data/UserResourceTest.java
@@ -10,11 +10,11 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.containers.MySqlDatabaseTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(MySqlDatabaseTestResource.class)
+@WithTestResource(MySqlDatabaseTestResource.class)
 class UserResourceTest {
 
     private final static String NEW_USER_ID = "3";

--- a/017-quartz-cluster/src/test/java/io/quarkus/qe/quartz/AnnotationScheduledJobsQuartzTest.java
+++ b/017-quartz-cluster/src/test/java/io/quarkus/qe/quartz/AnnotationScheduledJobsQuartzTest.java
@@ -17,11 +17,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.quarkus.qe.quartz.resources.QuartzNodeApplicationResource;
 import io.quarkus.qe.quartz.resources.RestApplicationResource;
 import io.quarkus.test.QuarkusProdModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.restassured.RestAssured;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(H2DatabaseTestResource.class)
 public class AnnotationScheduledJobsQuartzTest {
 
     private static final int REST_PORT = 8081;

--- a/019-quarkus-consul/src/test/java/io/quarkus/qe/GreetingResourceTest.java
+++ b/019-quarkus-consul/src/test/java/io/quarkus/qe/GreetingResourceTest.java
@@ -21,9 +21,9 @@ import com.orbitz.consul.KeyValueClient;
 
 import io.quarkus.qe.containers.ConsulTestResource;
 import io.quarkus.test.QuarkusProdModeTest;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 
-@QuarkusTestResource(ConsulTestResource.class)
+@WithTestResource(ConsulTestResource.class)
 public class GreetingResourceTest {
 
     private static final String APPLICATION_PROPERTIES = "application.properties";

--- a/021-quarkus-panache-multiple-pus/src/test/java/io/quarkus/qe/multiplepus/MultiplePersistenceUnitTest.java
+++ b/021-quarkus-panache-multiple-pus/src/test/java/io/quarkus/qe/multiplepus/MultiplePersistenceUnitTest.java
@@ -13,13 +13,13 @@ import io.quarkus.qe.multiplepus.containers.MariaDbDatabaseTestResource;
 import io.quarkus.qe.multiplepus.containers.PostgreSqlDatabaseTestResource;
 import io.quarkus.qe.multiplepus.model.fruit.Fruit;
 import io.quarkus.qe.multiplepus.model.vegetable.Vegetable;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(MariaDbDatabaseTestResource.class)
-@QuarkusTestResource(PostgreSqlDatabaseTestResource.class)
+@WithTestResource(MariaDbDatabaseTestResource.class)
+@WithTestResource(PostgreSqlDatabaseTestResource.class)
 class MultiplePersistenceUnitTest {
 
     private static boolean shouldCleanupFruit = false;

--- a/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceTest.java
+++ b/300-quarkus-vertx-webClient/src/test/java/io/quarkus/qe/vertx/webclient/ChuckNorrisResourceTest.java
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.vertx.webclient.resources.JaegerTestResource;
 import io.quarkus.qe.vertx.webclient.resources.WireMockChuckNorrisResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
 
 @QuarkusTest
-@QuarkusTestResource(WireMockChuckNorrisResource.class)
-@QuarkusTestResource(JaegerTestResource.class)
+@WithTestResource(WireMockChuckNorrisResource.class)
+@WithTestResource(JaegerTestResource.class)
 public class ChuckNorrisResourceTest {
     private final static String jaegerEndpoint = "http://localhost:16686/api/traces";
     static final String EXPECTED_ID = "aBanNLDwR-SAz7iMHuCiyw";

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/ConfluentKafkaTest.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/ConfluentKafkaTest.java
@@ -2,13 +2,13 @@ package io.quarkus.qe.kafka;
 
 import io.quarkus.qe.kafka.resources.ConfluentTestProfile;
 import io.quarkus.qe.kafka.resources.JaegerTestResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(ConfluentTestProfile.class)
-@QuarkusTestResource(JaegerTestResource.class)
+@WithTestResource(JaegerTestResource.class)
 public class ConfluentKafkaTest extends KafkaCommonTest {
     private static final String STOCK_MONITOR_SSE_ENDPOINT = "http://localhost:8081/stock/stream";
 

--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/StrimziKafkaTest.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/StrimziKafkaTest.java
@@ -2,13 +2,13 @@ package io.quarkus.qe.kafka;
 
 import io.quarkus.qe.kafka.resources.JaegerTestResource;
 import io.quarkus.qe.kafka.resources.StrimziTestProfile;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
 @TestProfile(StrimziTestProfile.class)
-@QuarkusTestResource(JaegerTestResource.class)
+@WithTestResource(JaegerTestResource.class)
 public class StrimziKafkaTest extends KafkaCommonTest {
 
     private static final String STOCK_MONITOR_SSE_ENDPOINT = "http://localhost:8081/stock/stream";

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/BladeRunnerHandlerTest.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/BladeRunnerHandlerTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.vertx.resources.RedisResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(RedisResource.class)
+@WithTestResource(RedisResource.class)
 public class BladeRunnerHandlerTest extends AbstractCommonTest {
     @Test
     @DisplayName("Retrieve bladeRunner by id")

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/NoSecuredResourceTest.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/NoSecuredResourceTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.vertx.resources.RedisResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-@QuarkusTestResource(RedisResource.class)
+@WithTestResource(RedisResource.class)
 public class NoSecuredResourceTest {
     @Test
     @DisplayName("no-secured resource. ")

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/ReplicantHandlerTest.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/ReplicantHandlerTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.vertx.resources.RedisResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(RedisResource.class)
+@WithTestResource(RedisResource.class)
 public class ReplicantHandlerTest extends AbstractCommonTest {
     @Test
     @DisplayName("Retrieve replicant by id")

--- a/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/SecuredResourceTest.java
+++ b/302-quarkus-vertx-jwt/src/test/java/io/quarkus/qe/vertx/web/SecuredResourceTest.java
@@ -6,12 +6,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.vertx.resources.RedisResource;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-@QuarkusTestResource(RedisResource.class)
+@WithTestResource(RedisResource.class)
 public class SecuredResourceTest extends AbstractCommonTest {
 
     @Test

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/TestResources.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.spring.data;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(value = H2DatabaseTestResource.class, restrictToAnnotatedClass = false)
 public class TestResources {
 }

--- a/603-spring-web-smallrye-openapi/src/test/java/io/quarkus/qe/books/TestResources.java
+++ b/603-spring-web-smallrye-openapi/src/test/java/io/quarkus/qe/books/TestResources.java
@@ -1,8 +1,8 @@
 package io.quarkus.qe.books;
 
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@QuarkusTestResource(H2DatabaseTestResource.class)
+@WithTestResource(H2DatabaseTestResource.class)
 public class TestResources {
 }


### PR DESCRIPTION
Updating deprecated @QuarkusTestResource to @WithTestResource as it's new in 3.13.0 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.13#quarkustestresource-replaced-by-withtestresource-gear-white_check_mark