### PR TITLE
Use quarkus-micrometer-registry-prometheus

### DIFF
--- a/015-quarkus-micrometer/pom.xml
+++ b/015-quarkus-micrometer/pom.xml
@@ -10,11 +10,7 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>


### PR DESCRIPTION
Use `quarkus-micrometer-registry-prometheus` instead of direct `io.micrometer:micrometer-registry-prometheus` usage