### PR TITLE
Change Quarkus reactive messaging artifact names

### DIFF
--- a/002-quarkus-all-extensions/pom.xml
+++ b/002-quarkus-all-extensions/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+            <artifactId>quarkus-messaging-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -154,7 +154,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
+            <artifactId>quarkus-messaging-amqp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -198,7 +198,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
+            <artifactId>quarkus-messaging</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -367,7 +367,7 @@
         <!--        </dependency>-->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-mqtt</artifactId>
+            <artifactId>quarkus-messaging-mqtt</artifactId>
         </dependency>
         <!-- New extensions in 1.7.1 comparing to 1.3.4 -->
         <!--        <dependency>-->

--- a/003-quarkus-many-extensions/pom.xml
+++ b/003-quarkus-many-extensions/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
+            <artifactId>quarkus-messaging-amqp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -119,7 +119,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+            <artifactId>quarkus-messaging-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -135,7 +135,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging</artifactId>
+            <artifactId>quarkus-messaging</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/301-quarkus-vertx-kafka/README.md
+++ b/301-quarkus-vertx-kafka/README.md
@@ -34,8 +34,8 @@ Vert.x Kafka exploratory test.
 * Test profiles (Strimzi/Confluent)
 
 **Brief description:** A [verticle][1] deployer launch a [periodic verticle][2] that is going to be producing random Stock-market values and push it to a Kafka Topic (`stock-price`). 
-A reactive kafka consumer (`quarkus-smallrye-reactive-messaging-kafka`) will be subscribed to this topic and will change the status of the incoming events from `pending` to `completed`, and moving these records to `end-stock-price` topic. 
-Note that there is another verticle `KStockPriceConsumer` launched by our verticle deployer, that does nothing. The reason is because `quarkus-smallrye-reactive-messaging-kafka` is already using vertx kafka client, 
+A reactive kafka consumer (`quarkus-messaging-kafka`) will be subscribed to this topic and will change the status of the incoming events from `pending` to `completed`, and moving these records to `end-stock-price` topic. 
+Note that there is another verticle `KStockPriceConsumer` launched by our verticle deployer, that does nothing. The reason is because `quarkus-messaging-kafka` is already using vertx kafka client, 
 so we don't really need a new verticle to consume Kafka in a reactive Non-blocking way. However, this verticle can be an example about how to deploy an abstract verticle from a verticle deployer.   
  
  [1]: https://vertx.io/docs/vertx-core/java/#_verticles

--- a/301-quarkus-vertx-kafka/pom.xml
+++ b/301-quarkus-vertx-kafka/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+            <artifactId>quarkus-messaging-kafka</artifactId>
         </dependency>
         <!-- Kafka -->
         <dependency>


### PR DESCRIPTION
This PR fixes the daily. These artifacts were renamed in Quarkus 3.9