### PR TITLE
Reduce log size in CI runs by suppressing download transfer progress

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -29,7 +29,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dno-test-modules
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dno-test-modules
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -71,7 +71,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify
+          mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -115,7 +115,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Test in Native mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -fae clean verify -Dnative \
+          mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative \
             -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
       - name: Zip Artifacts
@@ -159,7 +159,7 @@ jobs:
       - name: Test in JVM mode
         shell: bash
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml clean test
+          mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml clean test
       - name: Zip Artifacts
         shell: bash
         if: failure()
@@ -217,7 +217,7 @@ jobs:
         shell: bash
         run: |
           # Build on Native requires a lot of disk space, for now, we'll run only one module.
-          mvn -V -B -s .github/mvn-settings.xml -fae clean verify -Dnative -Dquarkus.native.native-image-xmx=6g -pl '003-quarkus-many-extensions'
+          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative -Dquarkus.native.native-image-xmx=6g -pl '003-quarkus-many-extensions'
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dno-test-modules
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dno-test-modules
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -69,7 +69,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Test in JVM mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -Dvalidate-format clean test
+          mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -Dvalidate-format clean test
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -129,7 +129,7 @@ jobs:
           done
 
           MODULES_ARG="${CHANGED// /,}"
-          mvn -am -fae -V -B -s .github/mvn-settings.xml -fae -pl $MODULES_ARG clean verify -Dnative \
+          mvn -am -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae -pl $MODULES_ARG clean verify -Dnative \
             -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
       - name: Zip Artifacts
@@ -175,7 +175,7 @@ jobs:
       - name: Test in JVM mode
         shell: bash
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml clean test
+          mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml clean test
       - name: Setup GraalVM
         id: setup-graalvm
         uses: graalvm/setup-graalvm@v1
@@ -190,7 +190,7 @@ jobs:
       - name: Smoke Test in Native mode
         shell: bash
         run: |
-          mvn -V -B -s .github/mvn-settings.xml -fae clean verify -Dnative \
+          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative \
             -Dquarkus.native.native-image-xmx=6g \
             -pl '003-quarkus-many-extensions'
       - name: Zip Artifacts


### PR DESCRIPTION
Reduces log heaviness. Adds `--batch-mode --no-transfer-progress` for maven execution to reduce "Downloading ...." messages