### PR TITLE
Raise native image Xmx to 7g in GitHub workflows testing native mode as build-time RSS increased due to upstream changes

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Test in Native mode
         run: |
           mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative \
-            -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g \
+            -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=7g \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
       - name: Zip Artifacts
         if: failure()
@@ -213,7 +213,7 @@ jobs:
         shell: bash
         run: |
           # Build on Native requires a lot of disk space, for now, we'll run only one module.
-          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative -Dquarkus.native.native-image-xmx=6g -pl '003-quarkus-many-extensions'
+          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative -Dquarkus.native.native-image-xmx=7g -pl '003-quarkus-many-extensions'
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -130,7 +130,7 @@ jobs:
 
           MODULES_ARG="${CHANGED// /,}"
           mvn -am -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae -pl $MODULES_ARG clean verify -Dnative \
-            -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=4g \
+            -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=7g \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
       - name: Zip Artifacts
         if: failure()
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative \
-            -Dquarkus.native.native-image-xmx=6g \
+            -Dquarkus.native.native-image-xmx=7g \
             -pl '003-quarkus-many-extensions'
       - name: Zip Artifacts
         shell: bash


### PR DESCRIPTION
Same situation as here https://github.com/quarkus-qe/quarkus-test-suite/pull/2153, please check it out for context.