### PR TITLE
Fix and refactor the scope of some resources

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Test in Native mode
         run: |
           mvn -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative \
-            -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=7g \
+            -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=8g \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
       - name: Zip Artifacts
         if: failure()
@@ -213,7 +213,7 @@ jobs:
         shell: bash
         run: |
           # Build on Native requires a lot of disk space, for now, we'll run only one module.
-          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative -Dquarkus.native.native-image-xmx=7g -pl '003-quarkus-many-extensions'
+          mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative -Dquarkus.native.native-image-xmx=8g -pl '003-quarkus-many-extensions'
       - name: Zip Artifacts
         shell: bash
         if: failure()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -130,7 +130,7 @@ jobs:
 
           MODULES_ARG="${CHANGED// /,}"
           mvn -am -fae -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae -pl $MODULES_ARG clean verify -Dnative \
-            -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=7g \
+            -Dquarkus.native.container-build=true -Dquarkus.native.native-image-xmx=8g \
             -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
       - name: Zip Artifacts
         if: failure()
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           mvn -V -B --no-transfer-progress -s .github/mvn-settings.xml -fae clean verify -Dnative \
-            -Dquarkus.native.native-image-xmx=7g \
+            -Dquarkus.native.native-image-xmx=8g \
             -pl '003-quarkus-many-extensions'
       - name: Zip Artifacts
         shell: bash

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/items/ItemsResourceTest.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/items/ItemsResourceTest.java
@@ -5,9 +5,13 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.common.TestResourceScope;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.RESTRICTED_TO_CLASS)
 public class ItemsResourceTest {
 
     /**

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/transaction/TransactionScopeBeanResourceTest.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/transaction/TransactionScopeBeanResourceTest.java
@@ -6,9 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.common.TestResourceScope;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.RESTRICTED_TO_CLASS)
 public class TransactionScopeBeanResourceTest {
 
     private static final String TRANSACTION_SCOPE_BASE_PATH = "/transaction-scope";

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/validator/JakartaPersistenceAndHibernateValidatorResourceTest.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/validator/JakartaPersistenceAndHibernateValidatorResourceTest.java
@@ -6,9 +6,13 @@ import static org.hamcrest.CoreMatchers.not;
 
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.common.TestResourceScope;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
+@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.RESTRICTED_TO_CLASS)
 public class JakartaPersistenceAndHibernateValidatorResourceTest {
 
     @Test

--- a/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/validator/TestResources.java
+++ b/004-quarkus-HHH-and-HV/src/test/java/io/quarkus/qe/hibernate/validator/TestResources.java
@@ -1,9 +1,0 @@
-package io.quarkus.qe.hibernate.validator;
-
-import io.quarkus.test.common.TestResourceScope;
-import io.quarkus.test.common.WithTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.MATCHING_RESOURCES)
-public class TestResources {
-}

--- a/006-quartz-manually-scheduled-job/src/test/java/io/quarkus/qe/quartz/TestResources.java
+++ b/006-quartz-manually-scheduled-job/src/test/java/io/quarkus/qe/quartz/TestResources.java
@@ -4,6 +4,6 @@ import io.quarkus.test.common.TestResourceScope;
 import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 
-@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.MATCHING_RESOURCES)
+@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.GLOBAL)
 public class TestResources {
 }

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/BookResourceTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/BookResourceTest.java
@@ -16,11 +16,15 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.spring.data.model.Book;
+import io.quarkus.test.common.TestResourceScope;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
 @QuarkusTest
+@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.MATCHING_RESOURCES)
 public class BookResourceTest {
 
     @Test

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CatResourceTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CatResourceTest.java
@@ -10,11 +10,15 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.qe.spring.data.model.Cat;
+import io.quarkus.test.common.TestResourceScope;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
 @QuarkusTest
+@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.MATCHING_RESOURCES)
 public class CatResourceTest {
     @Test
     void testCustomFindPublicationYearObjectBoolean() {

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/CommonsHeadersTest.java
@@ -12,12 +12,16 @@ import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.common.TestResourceScope;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
 
 @QuarkusTest
+@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.MATCHING_RESOURCES)
 public class CommonsHeadersTest {
     //This is for regression test for https://github.com/quarkusio/quarkus/pull/12234
     @Test

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/TestResources.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/data/TestResources.java
@@ -1,9 +1,0 @@
-package io.quarkus.qe.spring.data;
-
-import io.quarkus.test.common.TestResourceScope;
-import io.quarkus.test.common.WithTestResource;
-import io.quarkus.test.h2.H2DatabaseTestResource;
-
-@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.MATCHING_RESOURCES)
-public class TestResources {
-}

--- a/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/di/SpringDiTest.java
+++ b/601-spring-data-primitive-types/src/test/java/io/quarkus/qe/spring/di/SpringDiTest.java
@@ -12,11 +12,15 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InjectableBean;
+import io.quarkus.test.common.TestResourceScope;
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 
 import jakarta.enterprise.inject.spi.CDI;
 
 @QuarkusTest
+@WithTestResource(value = H2DatabaseTestResource.class, scope = TestResourceScope.MATCHING_RESOURCES)
 public class SpringDiTest {
 
     private static Stream<Class<?>> beanClassProvider() {


### PR DESCRIPTION
There was a bug in `TestResourceScope.MATCHING_RESOURCES` which made this work and was fixed in https://github.com/quarkusio/quarkus/pull/44279, I change it in this PR https://github.com/quarkus-qe/beefy-scenarios/pull/505 but it seems I wrongy understand the docs back then.

Not it should work as:
* `RESTRICTED_TO_CLASS` start for every test class, every test class need anotation
* `MATCHING_RESOURCES` start for specific group of test classes, every test class need anotation
* `GLOBAL` start for every test class, only one annotation

I change it to cover all 3 usages.