### PR TITLE
Change io.quarkus.oidc.token.propagation.AccessToken to io.quarkus.oidc.token.propagation.common.AccessToken

### DIFF
--- a/013-quarkus-oidc-restclient/src/main/java/io/quarkus/qe/ping/clients/TokenPropagationPongClient.java
+++ b/013-quarkus-oidc-restclient/src/main/java/io/quarkus/qe/ping/clients/TokenPropagationPongClient.java
@@ -2,7 +2,7 @@ package io.quarkus.qe.ping.clients;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import io.quarkus.oidc.token.propagation.AccessToken;
+import io.quarkus.oidc.token.propagation.common.AccessToken;
 import io.quarkus.qe.model.Score;
 
 import jakarta.ws.rs.Consumes;


### PR DESCRIPTION
Change io.quarkus.oidc.token.propagation.AccessToken to io.quarkus.oidc.token.propagation.common.AccessToken

io.quarkus.oidc.token.propagation.AccessToken was deprecated since 3.19 and removed for 3.28
https://github.com/quarkusio/quarkus/pull/49667