### PR TITLE
Enable ORM for 003-quarkus-many-extensions

### DIFF
--- a/003-quarkus-many-extensions/src/main/resources/application.properties
+++ b/003-quarkus-many-extensions/src/main/resources/application.properties
@@ -8,6 +8,3 @@ quarkus.devservices.enabled=false
 
 quarkus.oidc.auth-server-url=http://localhost:8180/auth/realms/test-realm
 quarkus.oidc.client-id=test-application-client
-
-# TODO remove once https://github.com/quarkusio/quarkus/issues/50247 is fixed
-quarkus.hibernate-orm.enabled=false


### PR DESCRIPTION
This reverts commit 2ca52351ab051b968359833b5da931e056f785d6 as the usptream issue was fixed