### PR TITLE
Drop ubi-quarkus-mandrel-builder-image:jdk-21 usage

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        image: [ "ubi-quarkus-graalvmce-builder-image:jdk-21", "ubi-quarkus-mandrel-builder-image:jdk-21" ]
+        image: [ "ubi-quarkus-graalvmce-builder-image:jdk-25", "ubi-quarkus-mandrel-builder-image:jdk-25" ]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        image: [ "ubi-quarkus-mandrel-builder-image:jdk-21"]
+        image: [ "ubi-quarkus-mandrel-builder-image:jdk-25"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5


### PR DESCRIPTION
Drop ubi-quarkus-mandrel-builder-image:jdk-21 usage

ubi-quarkus-mandrel-builder-image:jdk-25 is the way to go, one supported Mandrel version