### PR TITLE
Fix 301-quarkus-vertx-kafka after move to strimzi-test-container 0.115.0 in upstream

### DIFF
--- a/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/resources/StrimziKafkaResource.java
+++ b/301-quarkus-vertx-kafka/src/test/java/io/quarkus/qe/kafka/resources/StrimziKafkaResource.java
@@ -6,24 +6,25 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
-import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.Startables;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
-import io.strimzi.test.container.StrimziKafkaContainer;
+import io.strimzi.test.container.StrimziKafkaCluster;
 
 public class StrimziKafkaResource implements QuarkusTestResourceLifecycleManager {
 
     private static final Logger LOG = Logger.getLogger(ConfluentKafkaResource.class);
 
-    private StrimziKafkaContainer kafkaContainer;
+    private StrimziKafkaCluster kafkaContainer;
     private SchemaRegistryContainer schemaRegistry;
 
     @Override
     public Map<String, String> start() {
-        Network network = Network.newNetwork();
 
-        kafkaContainer = new StrimziKafkaContainer("quay.io/strimzi/kafka:latest-kafka-4.1.0").withNetwork(network);
+        kafkaContainer = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
+                .withImage("quay.io/strimzi/kafka:latest-kafka-4.1.0")
+                .withSharedNetwork()
+                .build();
         schemaRegistry = new SchemaRegistryContainer("quay.io/apicurio/apicurio-registry-mem", "2.4.2.Final", 8080);
 
         Startables.deepStart(Stream.of(kafkaContainer, schemaRegistry)).join();


### PR DESCRIPTION
Fix 301-quarkus-vertx-kafka after move to strimzi-test-container 0.115.0 in upstream