### PR TITLE
Replace legacy quarkus.hibernate-orm.database.generation with quarkus.hibernate-orm.schema-management.strategy

### DIFF
--- a/004-quarkus-HHH-and-HV/src/main/resources/application.properties
+++ b/004-quarkus-HHH-and-HV/src/main/resources/application.properties
@@ -3,5 +3,5 @@ quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:test
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.datasource.jdbc.min-size=3
 quarkus.datasource.jdbc.max-size=10
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql

--- a/011-quarkus-panache-rest-flyway/src/main/resources/application.properties
+++ b/011-quarkus-panache-rest-flyway/src/main/resources/application.properties
@@ -6,7 +6,7 @@ quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=sarah
 quarkus.datasource.password=connor
 quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/db?currentSchema=test
-quarkus.hibernate-orm.database.generation=validate
+quarkus.hibernate-orm.schema-management.strategy=validate
 
 # Flyway
 quarkus.flyway.migrate-at-start=true

--- a/014-quarkus-panache-with-transactions-xa/src/main/resources/application.properties
+++ b/014-quarkus-panache-with-transactions-xa/src/main/resources/application.properties
@@ -15,7 +15,7 @@ quarkus.datasource.with-xa.password=connor
 quarkus.datasource.with-xa.jdbc.url=jdbc:mysql://localhost:3306/db?currentSchema=test
 quarkus.datasource.with-xa.jdbc.transactions=xa
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
 
 %mysql_pool_test.quarkus.datasource.db-kind=mysql

--- a/601-spring-data-primitive-types/src/main/resources/application.properties
+++ b/601-spring-data-primitive-types/src/main/resources/application.properties
@@ -4,6 +4,6 @@ quarkus.datasource.jdbc.max-size=8
 quarkus.datasource.jdbc.min-size=2
 
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 %prod.quarkus.hibernate-orm.sql-load-script=import.sql

--- a/602-spring-data-rest/src/main/resources/application.properties
+++ b/602-spring-data-rest/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 # Using devServices
 quarkus.datasource.db-kind=postgresql
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql

--- a/603-spring-web-smallrye-openapi/src/main/resources/application.properties
+++ b/603-spring-web-smallrye-openapi/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name = Bootstrap Spring Boot
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:bootapp;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
 quarkus.log.console.format=%d{HH:mm:ss.SSS} [%t] %-5p %c{36} - %m%n
 quarkus.log.console.level=INFO


### PR DESCRIPTION
Replace legacy quarkus.hibernate-orm.database.generation with quarkus.hibernate-orm.schema-management.strategy

removes  WARN  [io.quarkus.config] (main) The "quarkus.hibernate-orm.database.generation" config property is deprecated and should not be used anymore.