### PR TITLE
Bump Mandrel from JDK 21 to JDK 25

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -180,7 +180,7 @@ jobs:
       matrix:
         java: [ 17 ]
         graalvm-version: ["mandrel-latest"]
-        graalvm-java-version: [ "21" ]
+        graalvm-java-version: [ "25" ]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -155,7 +155,7 @@ jobs:
       matrix:
         java: [ 17 ]
         graalvm-version: ["mandrel-latest"]
-        graalvm-java-version: [ "21" ]
+        graalvm-java-version: [ "25" ]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5


### PR DESCRIPTION
In our ci daily, it was failing on Windows native build:
https://github.com/quarkus-qe/beefy-scenarios/actions/runs/24966707753/job/73103830092
Bumping Mandrel from JDK 21 to JDK 25 will fix it