### PR TITLE
Build and use Quarkus 3.999-SNAPSHOT instead of 999-SNAPSHOT

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -29,7 +29,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dno-test-modules
+          git clone -b 3.x https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dno-test-modules
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus main
         run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dno-test-modules
+          git clone -b 3.x https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dno-test-modules -Dscalpel.enabled=false
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>3.999-SNAPSHOT</quarkus.platform.version>
         <!-- Default values for format -->
         <src.format.goal>format</src.format.goal>
         <src.sort.goal>sort</src.sort.goal>


### PR DESCRIPTION
Build and use Quarkus 3.999-SNAPSHOT instead of 999-SNAPSHOT. For some time we need to use Quarkus 3.x branch as it used for 3.x streams and the main is now for Quarkus 4.x